### PR TITLE
WiP: Iommu for Rust

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ Cargo.lock
 # IntellijIDEA files
 .idea/
 *.iml
+
+# Visual Studio Code files
+*.code-workspace

--- a/examples/echoer.rs
+++ b/examples/echoer.rs
@@ -54,8 +54,8 @@ pub fn main() {
     let mut counter = 0;
 
     loop {
-        echo(&mut buffer, &mut dev1, 0, 0);
-        echo(&mut buffer, &mut dev2, 0, 0);
+        echo(&mut buffer, &mut *dev1, 0, 0);
+        echo(&mut buffer, &mut *dev2, 0, 0);
 
         // don't poll the time unnecessarily
         if counter & 0xfff == 0 {
@@ -64,11 +64,11 @@ pub fn main() {
             // every second
             if nanos > 1_000_000_000 {
                 dev1.read_stats(&mut dev1_stats);
-                dev1_stats.print_stats_diff(&dev1, &dev1_stats_old, nanos);
+                dev1_stats.print_stats_diff(&*dev1, &dev1_stats_old, nanos);
                 dev1_stats_old = dev1_stats;
 
                 dev2.read_stats(&mut dev2_stats);
-                dev2_stats.print_stats_diff(&dev2, &dev2_stats_old, nanos);
+                dev2_stats.print_stats_diff(&*dev2, &dev2_stats_old, nanos);
                 dev2_stats_old = dev2_stats;
 
                 time = Instant::now();
@@ -81,7 +81,7 @@ pub fn main() {
 
 fn echo(
     buffer: &mut VecDeque<Packet>,
-    dev: &mut Box<IxyDevice>,
+    dev: &mut IxyDevice,
     rx_queue: u32,
     tx_queue: u32,
 ) {

--- a/examples/echoer.rs
+++ b/examples/echoer.rs
@@ -20,7 +20,7 @@ pub fn main() {
     let pci_addr_1 = match args.next() {
         Some(arg) => arg,
         None => {
-            eprintln!("Usage: cargo run --example forwarder <pci bus id1> <pci bus id2>");
+            eprintln!("Usage: cargo run --example echoer <pci bus id1> <pci bus id2>");
             process::exit(1);
         }
     };
@@ -28,16 +28,10 @@ pub fn main() {
     let pci_addr_2 = match args.next() {
         Some(arg) => arg,
         None => {
-            eprintln!("Usage: cargo run --example forwarder <pci bus id1> <pci bus id2>");
+            eprintln!("Usage: cargo run --example echoer <pci bus id1> <pci bus id2>");
             process::exit(1);
         }
     };
-
-    println!(
-        "{}\n{} {} {}",
-        "The forwarder is broken in the current implementation. Please use the echoer for performance tests:",
-        "cargo run --example echoer", pci_addr_1, pci_addr_2
-    );
 
     let mut dev1 = ixy_init(&pci_addr_1, 1, 1).unwrap();
     let mut dev2 = ixy_init(&pci_addr_2, 1, 1).unwrap();
@@ -60,8 +54,8 @@ pub fn main() {
     let mut counter = 0;
 
     loop {
-        forward(&mut buffer, &mut dev1, 0, &mut dev2, 0);
-        forward(&mut buffer, &mut dev2, 0, &mut dev1, 0);
+        echo(&mut buffer, &mut dev1, 0, 0);
+        echo(&mut buffer, &mut dev2, 0, 0);
 
         // don't poll the time unnecessarily
         if counter & 0xfff == 0 {
@@ -85,14 +79,13 @@ pub fn main() {
     }
 }
 
-fn forward(
+fn echo(
     buffer: &mut VecDeque<Packet>,
-    rx_dev: &mut impl IxyDevice,
+    dev: &mut impl IxyDevice,
     rx_queue: u32,
-    tx_dev: &mut impl IxyDevice,
     tx_queue: u32,
 ) {
-    let num_rx = rx_dev.rx_batch(rx_queue, buffer, BATCH_SIZE);
+    let num_rx = dev.rx_batch(rx_queue, buffer, BATCH_SIZE);
 
     if num_rx > 0 {
         // touch all packets for a realistic workload
@@ -100,7 +93,7 @@ fn forward(
             p[48] += 1;
         }
 
-        tx_dev.tx_batch(tx_queue, buffer);
+        dev.tx_batch(tx_queue, buffer);
 
         // drop packets if they haven't been sent out
         buffer.drain(..);

--- a/examples/echoer.rs
+++ b/examples/echoer.rs
@@ -81,7 +81,7 @@ pub fn main() {
 
 fn echo(
     buffer: &mut VecDeque<Packet>,
-    dev: &mut impl IxyDevice,
+    dev: &mut Box<IxyDevice>,
     rx_queue: u32,
     tx_queue: u32,
 ) {

--- a/examples/forwarder.rs
+++ b/examples/forwarder.rs
@@ -81,9 +81,9 @@ pub fn main() {
 
 fn forward(
     buffer: &mut VecDeque<Packet>,
-    rx_dev: &mut impl IxyDevice,
+    rx_dev: &mut Box<IxyDevice>,
     rx_queue: u32,
-    tx_dev: &mut impl IxyDevice,
+    tx_dev: &mut Box<IxyDevice>,
     tx_queue: u32,
 ) {
     let num_rx = rx_dev.rx_batch(rx_queue, buffer, BATCH_SIZE);

--- a/examples/forwarder.rs
+++ b/examples/forwarder.rs
@@ -54,8 +54,8 @@ pub fn main() {
     let mut counter = 0;
 
     loop {
-        forward(&mut buffer, &mut dev1, 0, &mut dev2, 0);
-        forward(&mut buffer, &mut dev2, 0, &mut dev1, 0);
+        forward(&mut buffer, &mut *dev1, 0, &mut *dev2, 0);
+        forward(&mut buffer, &mut *dev2, 0, &mut *dev1, 0);
 
         // don't poll the time unnecessarily
         if counter & 0xfff == 0 {
@@ -64,11 +64,11 @@ pub fn main() {
             // every second
             if nanos > 1_000_000_000 {
                 dev1.read_stats(&mut dev1_stats);
-                dev1_stats.print_stats_diff(&dev1, &dev1_stats_old, nanos);
+                dev1_stats.print_stats_diff(&*dev1, &dev1_stats_old, nanos);
                 dev1_stats_old = dev1_stats;
 
                 dev2.read_stats(&mut dev2_stats);
-                dev2_stats.print_stats_diff(&dev2, &dev2_stats_old, nanos);
+                dev2_stats.print_stats_diff(&*dev2, &dev2_stats_old, nanos);
                 dev2_stats_old = dev2_stats;
 
                 time = Instant::now();
@@ -81,9 +81,9 @@ pub fn main() {
 
 fn forward(
     buffer: &mut VecDeque<Packet>,
-    rx_dev: &mut Box<IxyDevice>,
+    rx_dev: &mut IxyDevice,
     rx_queue: u32,
-    tx_dev: &mut Box<IxyDevice>,
+    tx_dev: &mut IxyDevice,
     tx_queue: u32,
 ) {
     let num_rx = rx_dev.rx_batch(rx_queue, buffer, BATCH_SIZE);

--- a/examples/forwarder.rs
+++ b/examples/forwarder.rs
@@ -33,12 +33,6 @@ pub fn main() {
         }
     };
 
-    println!(
-        "{}\n{} {} {}",
-        "The forwarder is broken in the current implementation. Please use the echoer for performance tests:",
-        "cargo run --example echoer", pci_addr_1, pci_addr_2
-    );
-
     let mut dev1 = ixy_init(&pci_addr_1, 1, 1).unwrap();
     let mut dev2 = ixy_init(&pci_addr_2, 1, 1).unwrap();
 

--- a/examples/generator.rs
+++ b/examples/generator.rs
@@ -51,7 +51,7 @@ pub fn main() {
         // rest of the payload is zero-filled because mempools guarantee empty bufs
     ];
 
-    let pool = Mempool::allocate(NUM_PACKETS, 0, &dev).unwrap();
+    let pool = Mempool::allocate(NUM_PACKETS, 0, &*dev).unwrap();
 
     // pre-fill all packet buffer in the pool with data and return them to the packet pool
     {

--- a/examples/generator.rs
+++ b/examples/generator.rs
@@ -51,7 +51,7 @@ pub fn main() {
         // rest of the payload is zero-filled because mempools guarantee empty bufs
     ];
 
-    let pool = Mempool::allocate(NUM_PACKETS, 0).unwrap();
+    let pool = Mempool::allocate(NUM_PACKETS, 0, &dev).unwrap();
 
     // pre-fill all packet buffer in the pool with data and return them to the packet pool
     {

--- a/examples/generator.rs
+++ b/examples/generator.rs
@@ -121,5 +121,5 @@ fn calc_ip_checksum(packet: &mut Packet, offset: usize, len: usize) -> u16 {
             checksum = (checksum & 0xfff) + 1;
         }
     }
-    return !(checksum as u16);
+    !(checksum as u16)
 }

--- a/examples/generator.rs
+++ b/examples/generator.rs
@@ -101,7 +101,7 @@ pub fn main() {
             // every second
             if nanos > 1_000_000_000 {
                 dev.read_stats(&mut dev_stats);
-                dev_stats.print_stats_diff(&dev, &dev_stats_old, nanos);
+                dev_stats.print_stats_diff(&*dev, &dev_stats_old, nanos);
                 dev_stats_old = dev_stats;
 
                 time = Instant::now();

--- a/examples/generator.rs
+++ b/examples/generator.rs
@@ -6,7 +6,7 @@ use std::env;
 use std::process;
 use std::time::Instant;
 
-use ixy::memory::{alloc_pkt_batch, Packet, Mempool};
+use ixy::memory::{alloc_pkt_batch, Mempool, Packet};
 use ixy::*;
 
 // number of packets sent simultaneously by our driver

--- a/src/ixgbe.rs
+++ b/src/ixgbe.rs
@@ -1,3 +1,10 @@
+/* actually, there is no "dead" code. The code considered "dead" is needed so
+ * the files will not be closed after leaving scope. */
+#![allow(dead_code)]
+/* actually, all the assignments are used, but in unsafe code, so they are not
+ * recognized */
+#![allow(unused_assignments)]
+
 use std::collections::VecDeque;
 use std::error::Error;
 use std::fs;

--- a/src/ixgbe.rs
+++ b/src/ixgbe.rs
@@ -18,6 +18,7 @@ use libc;
 
 const DRIVER_NAME: &str = "ixy-ixgbe";
 
+const MIN_MEMPOOL_SIZE: usize = 4096;
 const NUM_RX_QUEUE_ENTRIES: usize = 512;
 const NUM_TX_QUEUE_ENTRIES: usize = 512;
 const TX_CLEAN_BATCH: usize = 32;
@@ -417,8 +418,8 @@ impl IxgbeDevice {
             self.set_reg32(IXGBE_RDH(u32::from(i)), 0);
             self.set_reg32(IXGBE_RDT(u32::from(i)), 0);
 
-            let mempool_size = if NUM_RX_QUEUE_ENTRIES + NUM_TX_QUEUE_ENTRIES < 4096 {
-                4096
+            let mempool_size = if NUM_RX_QUEUE_ENTRIES + NUM_TX_QUEUE_ENTRIES < MIN_MEMPOOL_SIZE {
+                MIN_MEMPOOL_SIZE
             } else {
                 NUM_RX_QUEUE_ENTRIES + NUM_TX_QUEUE_ENTRIES
             };

--- a/src/ixgbe.rs
+++ b/src/ixgbe.rs
@@ -17,7 +17,6 @@ use crate::MAX_QUEUES;
 use libc;
 
 const DRIVER_NAME: &str = "ixy-ixgbe";
-const DRIVER_IOMMU: bool = false;
 
 const NUM_RX_QUEUE_ENTRIES: usize = 512;
 const NUM_TX_QUEUE_ENTRIES: usize = 512;
@@ -36,6 +35,7 @@ pub struct IxgbeDevice {
     pub num_tx_queues: u16,
     pub rx_queues: Vec<IxgbeRxQueue>,
     pub tx_queues: Vec<IxgbeTxQueue>,
+    pub iommu: bool,
 }
 
 pub struct IxgbeRxQueue {
@@ -94,6 +94,7 @@ impl IxyDevice for IxgbeDevice {
             num_tx_queues,
             rx_queues,
             tx_queues,
+            iommu: false,
         };
 
         dev.reset_and_init(pci_addr)?;
@@ -107,8 +108,8 @@ impl IxyDevice for IxgbeDevice {
     }
 
     /// Returns the driver's iommu capability.
-    fn is_driver_iommu_capable(&self) -> bool {
-        DRIVER_IOMMU
+    fn is_card_iommu_capable(&self) -> bool {
+        self.iommu
     }
 
     /// Returns the VFIO container file descriptor.

--- a/src/ixgbe.rs
+++ b/src/ixgbe.rs
@@ -27,15 +27,15 @@ fn wrap_ring(index: usize, ring_size: usize) -> usize {
 }
 
 pub struct IxgbeDevice {
-    pub (crate) pci_addr: String,
-    pub (crate) addr: *mut u8,
-    pub (crate) len: usize,
-    pub (crate) num_rx_queues: u16,
-    pub (crate) num_tx_queues: u16,
-    pub (crate) rx_queues: Vec<IxgbeRxQueue>,
-    pub (crate) tx_queues: Vec<IxgbeTxQueue>,
-    pub (crate) iommu: bool,
-    pub (crate) vfio_container: RawFd,
+    pub(crate) pci_addr: String,
+    pub(crate) addr: *mut u8,
+    pub(crate) len: usize,
+    pub(crate) num_rx_queues: u16,
+    pub(crate) num_tx_queues: u16,
+    pub(crate) rx_queues: Vec<IxgbeRxQueue>,
+    pub(crate) tx_queues: Vec<IxgbeTxQueue>,
+    pub(crate) iommu: bool,
+    pub(crate) vfio_container: RawFd,
 }
 
 pub struct IxgbeRxQueue {
@@ -114,8 +114,12 @@ impl IxyDevice for IxgbeDevice {
 
     /// Returns the VFIO container file descriptor.
     /// When implementing non-VFIO / IOMMU devices, just return 0.
-    fn get_vfio_container(&self) -> RawFd {
-        self.vfio_container
+    fn get_vfio_container(&self) -> Option<RawFd> {
+        if self.iommu {
+            Some(self.vfio_container)
+        } else {
+            None
+        }
     }
 
     /// Returns the pci address of this device.
@@ -304,7 +308,7 @@ impl IxyDevice for IxgbeDevice {
 
 impl IxgbeDevice {
     /// Resets and initializes this device.
-    pub (crate) fn reset_and_init(&mut self, pci_addr: &str) -> Result<(), Box<Error>> {
+    pub(crate) fn reset_and_init(&mut self, pci_addr: &str) -> Result<(), Box<Error>> {
         info!("resetting device {}", pci_addr);
         // section 4.6.3.1 - disable all interrupts
         self.set_reg32(IXGBE_EIMC, 0x7fff_ffff);

--- a/src/ixgbe.rs
+++ b/src/ixgbe.rs
@@ -83,7 +83,6 @@ impl IxyDevice for IxgbeDevice {
         );
 
         let (addr, len) = pci_map_resource(pci_addr)?;
-
         let rx_queues = Vec::with_capacity(num_rx_queues as usize);
         let tx_queues = Vec::with_capacity(num_tx_queues as usize);
         let mut dev = IxgbeDevice {
@@ -305,7 +304,7 @@ impl IxyDevice for IxgbeDevice {
 
 impl IxgbeDevice {
     /// Resets and initializes this device.
-    pub fn reset_and_init(&mut self, pci_addr: &str) -> Result<(), Box<Error>> {
+    pub (crate) fn reset_and_init(&mut self, pci_addr: &str) -> Result<(), Box<Error>> {
         info!("resetting device {}", pci_addr);
         // section 4.6.3.1 - disable all interrupts
         self.set_reg32(IXGBE_EIMC, 0x7fff_ffff);

--- a/src/ixgbe.rs
+++ b/src/ixgbe.rs
@@ -27,17 +27,18 @@ fn wrap_ring(index: usize, ring_size: usize) -> usize {
     (index + 1) & (ring_size - 1)
 }
 
+// ToDo(stefan.huber@stusta.de): Make this stuff crate visible as soon as it is stable
 pub struct IxgbeDevice {
-    pci_addr: String,
-    addr: *mut u8,
-    len: usize,
-    num_rx_queues: u16,
-    num_tx_queues: u16,
-    rx_queues: Vec<IxgbeRxQueue>,
-    tx_queues: Vec<IxgbeTxQueue>,
+    pub pci_addr: String,
+    pub addr: *mut u8,
+    pub len: usize,
+    pub num_rx_queues: u16,
+    pub num_tx_queues: u16,
+    pub rx_queues: Vec<IxgbeRxQueue>,
+    pub tx_queues: Vec<IxgbeTxQueue>,
 }
 
-struct IxgbeRxQueue {
+pub struct IxgbeRxQueue {
     descriptors: *mut ixgbe_adv_rx_desc,
     num_descriptors: usize,
     pool: Rc<Mempool>,
@@ -45,7 +46,7 @@ struct IxgbeRxQueue {
     rx_index: usize,
 }
 
-struct IxgbeTxQueue {
+pub struct IxgbeTxQueue {
     descriptors: *mut ixgbe_adv_tx_desc,
     num_descriptors: usize,
     pool: Option<Rc<Mempool>>,

--- a/src/ixgbe.rs
+++ b/src/ixgbe.rs
@@ -141,7 +141,7 @@ impl IxyDevice for IxgbeDevice {
 
         // check if iommu is activated
         // iommu is activated if there is a iommu_group symlink in /sys/bus/pci/devices/$pci_addr
-        let iommu = Path::new(&format!("/sys/bus/pci/devices/{}/iommu_group/", pci_addr)).exists();
+        let iommu = Path::new(&format!("/sys/bus/pci/devices/{}/iommu_group", pci_addr)).exists();
         // ToDo (stefan.huber@stusta.de): unload ixgbe driver, load vfio driver (nicetohave)
         let vfio_dfd: i32;
         let vfio_gfd: i32;
@@ -161,7 +161,7 @@ impl IxyDevice for IxgbeDevice {
                 .open("/dev/vfio/vfio")?.as_raw_fd();
 
             /* find vfio group for device */
-            let link = fs::read_link(format!("/sys/bus/pci/devices/{}/iommu_group/", pci_addr))?;
+            let link = fs::read_link(format!("/sys/bus/pci/devices/{}/iommu_group", pci_addr))?;
             let group = link.file_name().unwrap().to_str().unwrap().parse::<i32>().unwrap();
             unsafe {
                 /* check IOMMU API version */

--- a/src/ixgbe.rs
+++ b/src/ixgbe.rs
@@ -36,6 +36,7 @@ pub struct IxgbeDevice {
     pub rx_queues: Vec<IxgbeRxQueue>,
     pub tx_queues: Vec<IxgbeTxQueue>,
     pub iommu: bool,
+    pub vfio_container: RawFd,
 }
 
 pub struct IxgbeRxQueue {
@@ -95,6 +96,7 @@ impl IxyDevice for IxgbeDevice {
             rx_queues,
             tx_queues,
             iommu: false,
+            vfio_container: 0,
         };
 
         dev.reset_and_init(pci_addr)?;
@@ -115,7 +117,7 @@ impl IxyDevice for IxgbeDevice {
     /// Returns the VFIO container file descriptor.
     /// When implementing non-VFIO / IOMMU devices, just return 0.
     fn get_vfio_container(&self) -> RawFd {
-        0
+        self.vfio_container
     }
 
     /// Returns the pci address of this device.

--- a/src/ixgbe.rs
+++ b/src/ixgbe.rs
@@ -26,17 +26,16 @@ fn wrap_ring(index: usize, ring_size: usize) -> usize {
     (index + 1) & (ring_size - 1)
 }
 
-// ToDo(stefan.huber@stusta.de): Make this stuff crate visible as soon as it is stable
 pub struct IxgbeDevice {
-    pub pci_addr: String,
-    pub addr: *mut u8,
-    pub len: usize,
-    pub num_rx_queues: u16,
-    pub num_tx_queues: u16,
-    pub rx_queues: Vec<IxgbeRxQueue>,
-    pub tx_queues: Vec<IxgbeTxQueue>,
-    pub iommu: bool,
-    pub vfio_container: RawFd,
+    pub (crate) pci_addr: String,
+    pub (crate) addr: *mut u8,
+    pub (crate) len: usize,
+    pub (crate) num_rx_queues: u16,
+    pub (crate) num_tx_queues: u16,
+    pub (crate) rx_queues: Vec<IxgbeRxQueue>,
+    pub (crate) tx_queues: Vec<IxgbeTxQueue>,
+    pub (crate) iommu: bool,
+    pub (crate) vfio_container: RawFd,
 }
 
 pub struct IxgbeRxQueue {

--- a/src/ixgbe.rs
+++ b/src/ixgbe.rs
@@ -129,6 +129,7 @@ impl IxyDevice for IxgbeDevice {
         // iommu is activated if there is a iommu_group symlink in /sys/bus/pci/devices/$pci_addr
         let iommu = Path::new(&format!("/sys/bus/pci/devices/{}/iommu_group", pci_addr)).exists();
         // ToDo (stefan.huber@stusta.de): unload ixgbe driver, load vfio driver (nicetohave)
+        // ToDo (stefan.huber@stusta.de): at least give a error message when vfio is not loaded...
         let device_file_descriptor: RawFd;
         let group_file: Option<File>;
         let gfd: RawFd;

--- a/src/ixgbe.rs
+++ b/src/ixgbe.rs
@@ -296,14 +296,14 @@ impl IxyDevice for IxgbeDevice {
                     libc::MAP_SHARED,
                     devicefile.as_raw_fd(),
                     bar0_reg.offset as i64,
-                ) as *mut u8;
-                if ptr == libc::MAP_FAILED as *mut u8 {
+                );
+                if ptr == libc::MAP_FAILED {
                     error!(
                         "[ERROR]Could not mmap bar0. Errno: {}",
                         *libc::__errno_location()
                     );
                 }
-                addr = ptr;
+                addr = ptr as *mut u8;
             }
         } else {
             device_file_descriptor = -1;

--- a/src/ixgbe.rs
+++ b/src/ixgbe.rs
@@ -54,6 +54,7 @@ struct vfio_group_status {
 }
 
 /* struct vfio_region_info, grabbed from linux/vfio.h */
+#[repr(C)]
 struct vfio_region_info {
     argsz: u32,
     flags: u32,

--- a/src/ixgbeiommu.rs
+++ b/src/ixgbeiommu.rs
@@ -1,0 +1,363 @@
+/* actually, there is no "dead" code. The code considered "dead" is needed so
+ * the files will not be closed after leaving scope. */
+//#![allow(dead_code)]
+/* actually, all the assignments are used, but in unsafe code, so they are not
+ * recognized */
+//#![allow(unused_assignments)]
+
+use std::collections::VecDeque;
+use std::error::Error;
+use std::fs;
+use std::fs::{File, OpenOptions};
+use std::mem;
+use std::os::unix::io::RawFd;
+use std::os::unix::io::{AsRawFd, FromRawFd};
+use std::ptr;
+
+use crate::ixgbe::IxgbeDevice;
+use crate::memory::*;
+use crate::pci::*;
+
+use crate::DeviceStats;
+use crate::IxyDevice;
+use crate::MAX_QUEUES;
+use libc;
+
+const DRIVER_NAME: &str = "ixy-ixgbe-iommu";
+const DRIVER_IOMMU: bool = true;
+
+/* constants needed for IOMMU. Grabbed from linux/vfio.h */
+const VFIO_GET_API_VERSION: u64 = 15204;
+const VFIO_CHECK_EXTENSION: u64 = 15205;
+const VFIO_SET_IOMMU: u64 = 15206;
+const VFIO_GROUP_GET_STATUS: u64 = 15207;
+const VFIO_GROUP_SET_CONTAINER: u64 = 15208;
+const VFIO_GROUP_GET_DEVICE_FD: u64 = 15210;
+const VFIO_DEVICE_GET_REGION_INFO: u64 = 15212;
+
+const VFIO_API_VERSION: i32 = 0;
+const VFIO_TYPE1_IOMMU: u64 = 1;
+const VFIO_GROUP_FLAGS_VIABLE: u32 = 1;
+const VFIO_PCI_CONFIG_REGION_INDEX: u32 = 7;
+const VFIO_PCI_BAR0_REGION_INDEX: u32 = 0;
+
+static mut CONTAINER_FILE: Option<File> = None;
+static mut CFD: RawFd = 0;
+
+/* struct vfio_group_status, grabbed from linux/vfio.h */
+#[allow(non_camel_case_types)]
+#[repr(C)]
+struct vfio_group_status {
+    argsz: u32,
+    flags: u32,
+}
+
+/* struct vfio_region_info, grabbed from linux/vfio.h */
+#[allow(non_camel_case_types)]
+#[repr(C)]
+struct vfio_region_info {
+    argsz: u32,
+    flags: u32,
+    index: u32,
+    cap_offset: u32,
+    size: u64,
+    offset: u64,
+}
+
+pub struct IxgbeIommuDevice {
+    dev: IxgbeDevice,
+    dfd: RawFd,
+    group_file: Option<File>,
+    gfd: RawFd,
+    pub cfd: RawFd,
+}
+
+impl IxyDevice for IxgbeIommuDevice {
+    /// Returns an initialized `IxgbeDevice` on success.
+    ///
+    /// # Panics
+    /// Panics if `num_rx_queues` or `num_tx_queues` exceeds `MAX_QUEUES`.
+    fn init(
+        pci_addr: &str,
+        num_rx_queues: u16,
+        num_tx_queues: u16,
+    ) -> Result<IxgbeIommuDevice, Box<Error>> {
+        if unsafe { libc::getuid() } != 0 {
+            warn!("not running as root, this will probably fail");
+        }
+
+        assert!(
+            num_rx_queues <= MAX_QUEUES,
+            "cannot configure {} rx queues: limit is {}",
+            num_rx_queues,
+            MAX_QUEUES
+        );
+        assert!(
+            num_tx_queues <= MAX_QUEUES,
+            "cannot configure {} tx queues: limit is {}",
+            num_tx_queues,
+            MAX_QUEUES
+        );
+
+        // check if iommu is activated
+        // ToDo (stefan.huber@stusta.de): unload ixgbe driver, load vfio driver (nicetohave)
+        // ToDo (stefan.huber@stusta.de): at least give a error message when vfio is not loaded...
+        let dfd: RawFd;
+        let group_file: Option<File>;
+        let gfd: RawFd;
+        let addr: *mut u8;
+        let len: usize;
+        let mut cfd: RawFd = unsafe { CFD };
+        /* we also have to build this vfio struct... */
+        let group_status: vfio_group_status = vfio_group_status {
+            argsz: mem::size_of::<vfio_group_status> as u32,
+            flags: 0,
+        };
+
+        let mut first_time_setup = false;
+
+        unsafe {
+            /* if the VFIO container is not initialized yet... */
+            if CONTAINER_FILE.is_none() {
+                /* ...initialize it */
+                first_time_setup = true;
+                /* Open new VFIO Container */
+                CONTAINER_FILE = Some(
+                    OpenOptions::new()
+                        .read(true)
+                        .write(true)
+                        .open("/dev/vfio/vfio")?,
+                );
+                CFD = get_raw_fd(&CONTAINER_FILE);
+                cfd = CFD;
+                /* check IOMMU API version */
+                if libc::ioctl(cfd, VFIO_GET_API_VERSION) != VFIO_API_VERSION {
+                    info!("Unknown VFIO API Version. Application will probably die soon(ish).");
+                }
+
+                /* check if device supports Type1 IOMMU */
+                if libc::ioctl(cfd, VFIO_CHECK_EXTENSION, VFIO_TYPE1_IOMMU) != 1 {
+                    info!("Device doesn't support Type1 IOMMU. Application will probably crash soon(ish).");
+                }
+            }
+        }
+
+        /* find vfio group for device */
+        let link = fs::read_link(format!("/sys/bus/pci/devices/{}/iommu_group", pci_addr))?;
+        let group = link
+            .file_name()
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .parse::<i32>()
+            .unwrap();
+        unsafe {
+            /* open the devices' group */
+            group_file = Some(
+                OpenOptions::new()
+                    .read(true)
+                    .write(true)
+                    .open(format!("/dev/vfio/{}", group))?,
+            );
+            gfd = get_raw_fd(&group_file);
+
+            /* Test the group is viable and available */
+            if libc::ioctl(gfd, VFIO_GROUP_GET_STATUS, &group_status) == -1 {
+                error!(
+                    "[ERROR]Could not VFIO_GROUP_GET_STATUS. Errno: {}",
+                    *libc::__errno_location()
+                );
+            }
+            if (group_status.flags & VFIO_GROUP_FLAGS_VIABLE) != 1 {
+                info!("Group is not viable (ie, not all devices bound for vfio). Application will probably crash soon(ish).");
+            }
+
+            /* Add the group to the container */
+            if libc::ioctl(gfd, VFIO_GROUP_SET_CONTAINER, &cfd) == -1 {
+                error!(
+                    "[ERROR]Could not VFIO_GROUP_SET_CONTAINER. Errno: {}",
+                    *libc::__errno_location()
+                );
+            }
+
+            if first_time_setup {
+                /* Enable the IOMMU model we want */
+                if libc::ioctl(cfd, VFIO_SET_IOMMU, VFIO_TYPE1_IOMMU) == -1 {
+                    error!(
+                        "[ERROR]Could not VFIO_SET_IOMMU to VFIO_TYPE1_IOMMU. Errno: {}",
+                        *libc::__errno_location()
+                    );
+                }
+            }
+
+            /* Get a file descriptor for the device */
+            dfd = libc::ioctl(gfd, VFIO_GROUP_GET_DEVICE_FD, pci_addr);
+            if dfd == -1 {
+                error!(
+                    "[ERROR]Could not VFIO_GROUP_GET_DEVICE_FD. Errno: {}",
+                    *libc::__errno_location()
+                );
+            }
+
+            /* Get region info for config region */
+            let conf_reg: vfio_region_info = vfio_region_info {
+                argsz: mem::size_of::<vfio_region_info> as u32,
+                flags: 0,
+                index: VFIO_PCI_CONFIG_REGION_INDEX,
+                cap_offset: 0,
+                size: 0,
+                offset: 0,
+            };
+            if libc::ioctl(dfd, VFIO_DEVICE_GET_REGION_INFO, &conf_reg) == -1 {
+                error!("[ERROR]Could not VFIO_DEVICE_GET_REGION_INFO for index VFIO_PCI_CONFIG_REGION_INDEX. Errno: {}", *libc::__errno_location());
+            }
+
+            /* set DMA bit */
+            let device_file = File::from_raw_fd(dfd);
+
+            let mut dma: u16 = 0;
+            let dma_ptr: *mut u16 = &mut dma;
+            if libc::pread(
+                dfd,
+                dma_ptr as *mut libc::c_void,
+                2,
+                (conf_reg.offset + COMMAND_REGISTER_OFFSET) as i64,
+            ) == -1
+            {
+                error!(
+                    "[ERROR]Could not pread. Errno: {}",
+                    *libc::__errno_location()
+                );
+            }
+
+            dma |= 1 << BUS_MASTER_ENABLE_BIT;
+
+            if libc::pwrite(
+                dfd,
+                dma_ptr as *mut libc::c_void,
+                2,
+                (conf_reg.offset + COMMAND_REGISTER_OFFSET) as i64,
+            ) == -1
+            {
+                error!(
+                    "[ERROR]Could not pwrite. Errno: {}",
+                    *libc::__errno_location()
+                );
+            }
+
+            /* map BAR0 space */
+            let bar0_reg: vfio_region_info = vfio_region_info {
+                argsz: mem::size_of::<vfio_region_info> as u32,
+                flags: 0,
+                index: VFIO_PCI_BAR0_REGION_INDEX,
+                cap_offset: 0,
+                size: 0,
+                offset: 0,
+            };
+            if libc::ioctl(dfd, VFIO_DEVICE_GET_REGION_INFO, &bar0_reg) == -1 {
+                error!("[ERROR]Could not VFIO_DEVICE_GET_REGION_INFO for index VFIO_PCI_BAR0_REGION_INDEX. Errno: {}", *libc::__errno_location());
+            }
+
+            len = bar0_reg.size as usize;
+
+            let ptr = libc::mmap(
+                ptr::null_mut(),
+                len,
+                libc::PROT_READ | libc::PROT_WRITE,
+                libc::MAP_SHARED,
+                device_file.as_raw_fd(),
+                bar0_reg.offset as i64,
+            );
+            if ptr == libc::MAP_FAILED {
+                error!(
+                    "[ERROR]Could not mmap bar0. Errno: {}",
+                    *libc::__errno_location()
+                );
+            }
+            addr = ptr as *mut u8;
+        }
+
+        let rx_queues = Vec::with_capacity(num_rx_queues as usize);
+        let tx_queues = Vec::with_capacity(num_tx_queues as usize);
+
+        let mut ixgbedev = IxgbeDevice {
+            pci_addr: pci_addr.to_string(),
+            addr,
+            len,
+            num_rx_queues,
+            num_tx_queues,
+            rx_queues,
+            tx_queues,
+        };
+
+        ixgbedev.reset_and_init(pci_addr)?;
+
+        let mut dev = IxgbeIommuDevice {
+            dev: ixgbedev,
+            dfd,
+            group_file,
+            gfd,
+            cfd,
+        };
+
+        Ok(dev)
+    }
+
+    /// Returns the driver's name of this device.
+    fn get_driver_name(&self) -> &str {
+        DRIVER_NAME
+    }
+
+    /// Returns the driver's iommu capability.
+    fn is_driver_iommu_capable(&self) -> bool {
+        DRIVER_IOMMU
+    }
+
+    /// Returns the VFIO container file descriptor.
+    /// When implementing non-VFIO / IOMMU devices, just return 0.
+    fn get_vfio_container(&self) -> RawFd {
+        CFD
+    }
+
+    /// Returns the pci address of this device.
+    fn get_pci_addr(&self) -> &str {
+        self.dev.get_pci_addr()
+    }
+
+    /// Pushes up to `num_packets` received `Packet`s onto `buffer`.
+    fn rx_batch(
+        &mut self,
+        queue_id: u32,
+        buffer: &mut VecDeque<Packet>,
+        num_packets: usize,
+    ) -> usize {
+        self.dev.rx_batch(queue_id, buffer, num_packets)
+    }
+
+    /// Pops as many packets as possible from `packets` to put them into the device`s tx queue.
+    fn tx_batch(&mut self, queue_id: u32, packets: &mut VecDeque<Packet>) -> usize {
+        self.dev.tx_batch(queue_id, packets)
+    }
+
+    /// Reads the stats of this device into `stats`.
+    fn read_stats(&self, stats: &mut DeviceStats) {
+        self.dev.read_stats(stats)
+    }
+
+    /// Resets the stats of this device.
+    fn reset_stats(&self) {
+        self.dev.reset_stats()
+    }
+
+    /// Returns the link speed of this device.
+    fn get_link_speed(&self) -> u16 {
+        self.dev.get_link_speed()
+    }
+}
+
+fn get_raw_fd(f: &Option<File>) -> RawFd {
+    match *f {
+        Some(ref x) => x.as_raw_fd(),
+        None => -1,
+    }
+}

--- a/src/ixgbeiommu.rs
+++ b/src/ixgbeiommu.rs
@@ -294,6 +294,7 @@ impl IxyDevice for IxgbeIommuDevice {
             rx_queues,
             tx_queues,
             iommu: true,
+            vfio_container: cfd,
         };
 
         ixgbedev.reset_and_init(pci_addr)?;

--- a/src/ixgbeiommu.rs
+++ b/src/ixgbeiommu.rs
@@ -65,7 +65,7 @@ pub struct IxgbeIommuDevice {
 }
 
 impl IxyDevice for IxgbeIommuDevice {
-    /// Returns an initialized `IxgbeDevice` on success.
+    /// Returns an initialized `IxgbeIommuDevice` on success.
     ///
     /// # Panics
     /// Panics if `num_rx_queues` or `num_tx_queues` exceeds `MAX_QUEUES`.
@@ -99,7 +99,7 @@ impl IxyDevice for IxgbeIommuDevice {
         let mut cfd: RawFd = unsafe { CFD };
         /* we also have to build this vfio struct... */
         let group_status: vfio_group_status = vfio_group_status {
-            argsz: mem::size_of::<vfio_group_status> as u32,
+            argsz: mem::size_of::<vfio_group_status> as usize as u32,
             flags: 0,
         };
 
@@ -192,7 +192,7 @@ impl IxyDevice for IxgbeIommuDevice {
 
         /* map BAR0 space */
         let bar0_reg: vfio_region_info = vfio_region_info {
-            argsz: mem::size_of::<vfio_region_info> as u32,
+            argsz: mem::size_of::<vfio_region_info> as usize as u32,
             flags: 0,
             index: VFIO_PCI_BAR0_REGION_INDEX,
             cap_offset: 0,
@@ -259,8 +259,8 @@ impl IxyDevice for IxgbeIommuDevice {
 
     /// Returns the VFIO container file descriptor.
     /// When implementing non-VFIO / IOMMU devices, just return 0.
-    fn get_vfio_container(&self) -> RawFd {
-        self.dev.vfio_container
+    fn get_vfio_container(&self) -> Option<RawFd> {
+        Some(self.dev.vfio_container)
     }
 
     /// Returns the pci address of this device.
@@ -303,7 +303,7 @@ impl IxyDevice for IxgbeIommuDevice {
 fn enable_dma(device_file_descriptor: RawFd) {
     /* Get region info for config region */
     let conf_reg: vfio_region_info = vfio_region_info {
-        argsz: mem::size_of::<vfio_region_info> as u32,
+        argsz: mem::size_of::<vfio_region_info> as usize as u32,
         flags: 0,
         index: VFIO_PCI_CONFIG_REGION_INDEX,
         cap_offset: 0,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ extern crate libc;
 extern crate log;
 
 mod constants;
-pub mod ixgbe;
+mod ixgbe;
 pub mod memory;
 mod pci;
 
@@ -92,10 +92,10 @@ pub trait IxyDevice {
     /// Resets the network card's stats registers.
     ///
     /// # Examples
-    ///IxyDevice
-    ///IxyDevice
-    ///IxyDevice
-    ///IxyDevice
+    ///
+    /// ```rust,no_run
+    /// use ixy::*;
+    ///
     /// let mut dev = ixy_init("0000:01:00.0", 1, 1).unwrap();
     /// dev.reset_stats();
     /// ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -171,7 +171,11 @@ impl DeviceStats {
 /// Initializes the network card at `pci_addr`.
 ///
 /// `rx_queues` and `tx_queues` specify the number of queues that will be initialized and used.
-pub fn ixy_init(pci_addr: &str, rx_queues: u16, tx_queues: u16) -> Result<IxgbeDevice, Box<Error>> {
+pub fn ixy_init(
+    pci_addr: &str,
+    rx_queues: u16,
+    tx_queues: u16,
+) -> Result<IxgbeDevice, Box<Error>> {
     let mut config_file = pci_open_resource(pci_addr, "config").expect("wrong pci address");
 
     let vendor_id = read_io16(&mut config_file, 0)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,7 +136,7 @@ pub struct DeviceStats {
 
 impl DeviceStats {
     ///  Prints the stats differences between `stats_old` and `self`.
-    pub fn print_stats_diff(&self, dev: &Box<IxyDevice>, stats_old: &DeviceStats, nanos: u32) {
+    pub fn print_stats_diff(&self, dev: &IxyDevice, stats_old: &DeviceStats, nanos: u32) {
         let pci_addr = dev.get_pci_addr();
         let mbits = self.diff_mbit(
             self.rx_bytes,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,8 +37,8 @@ pub trait IxyDevice {
     /// Returns the driver's name.
     fn get_driver_name(&self) -> &str;
 
-    /// Returns the driver's iommu capability.
-    fn is_driver_iommu_capable(&self) -> bool;
+    /// Returns the card's iommu capability.
+    fn is_card_iommu_capable(&self) -> bool;
 
     /// Returns the VFIO container file descriptor.
     /// When implementing non-VFIO / IOMMU devices, just return 0.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,7 @@ pub trait IxyDevice {
 
     /// Returns the VFIO container file descriptor.
     /// When implementing non-VFIO / IOMMU devices, just return 0.
-    fn get_vfio_container(&self) -> RawFd;
+    fn get_vfio_container(&self) -> Option<RawFd>;
 
     /// Returns the network card's pci address.
     fn get_pci_addr(&self) -> &str;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,7 +136,7 @@ pub struct DeviceStats {
 
 impl DeviceStats {
     ///  Prints the stats differences between `stats_old` and `self`.
-    pub fn print_stats_diff(&self, dev: &impl IxyDevice, stats_old: &DeviceStats, nanos: u32) {
+    pub fn print_stats_diff(&self, dev: &Box<IxyDevice>, stats_old: &DeviceStats, nanos: u32) {
         let pci_addr = dev.get_pci_addr();
         let mbits = self.diff_mbit(
             self.rx_bytes,
@@ -186,7 +186,7 @@ pub fn ixy_init(
     pci_addr: &str,
     rx_queues: u16,
     tx_queues: u16,
-) -> Result<impl IxyDevice, Box<Error>> {
+) -> Result<Box<IxyDevice>, Box<Error>> {
     let mut config_file = pci_open_resource(pci_addr, "config").expect("wrong pci address");
 
     let vendor_id = read_io16(&mut config_file, 0)?;
@@ -204,10 +204,10 @@ pub fn ixy_init(
         // let's give it a try with ixgbe
         if iommu {
             let device: IxgbeIommuDevice = IxgbeIommuDevice::init(pci_addr, rx_queues, tx_queues)?;
-            Ok(device)
+            Ok(Box::new(device))
         } else {
             let device: IxgbeDevice = IxgbeDevice::init(pci_addr, rx_queues, tx_queues)?;
-            Ok(device)
+            Ok(Box::new(device))
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ extern crate libc;
 extern crate log;
 
 mod constants;
-mod ixgbe;
+pub mod ixgbe;
 pub mod memory;
 mod pci;
 
@@ -92,10 +92,10 @@ pub trait IxyDevice {
     /// Resets the network card's stats registers.
     ///
     /// # Examples
-    ///
-    /// ```rust,no_run
-    /// use ixy::*;
-    ///
+    ///IxyDevice
+    ///IxyDevice
+    ///IxyDevice
+    ///IxyDevice
     /// let mut dev = ixy_init("0000:01:00.0", 1, 1).unwrap();
     /// dev.reset_stats();
     /// ```
@@ -175,7 +175,7 @@ pub fn ixy_init(
     pci_addr: &str,
     rx_queues: u16,
     tx_queues: u16,
-) -> Result<impl IxyDevice, Box<Error>> {
+) -> Result<IxgbeDevice, Box<Error>> {
     let mut config_file = pci_open_resource(pci_addr, "config").expect("wrong pci address");
 
     let vendor_id = read_io16(&mut config_file, 0)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -171,11 +171,7 @@ impl DeviceStats {
 /// Initializes the network card at `pci_addr`.
 ///
 /// `rx_queues` and `tx_queues` specify the number of queues that will be initialized and used.
-pub fn ixy_init(
-    pci_addr: &str,
-    rx_queues: u16,
-    tx_queues: u16,
-) -> Result<IxgbeDevice, Box<Error>> {
+pub fn ixy_init(pci_addr: &str, rx_queues: u16, tx_queues: u16) -> Result<IxgbeDevice, Box<Error>> {
     let mut config_file = pci_open_resource(pci_addr, "config").expect("wrong pci address");
 
     let vendor_id = read_io16(&mut config_file, 0)?;

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -52,7 +52,7 @@ impl<T> Dma<T> {
             size
         };
 
-        if dev.is_driver_iommu_capable() {
+        if dev.is_card_iommu_capable() {
             // get an anonymous mapped memory space from kernel
             let ptr = unsafe {
                 libc::mmap(
@@ -243,7 +243,7 @@ impl Mempool {
         let mut phys_addresses = Vec::with_capacity(entries);
 
         for i in 0..entries {
-            if dev.is_driver_iommu_capable() {
+            if dev.is_card_iommu_capable() {
                 phys_addresses.push(unsafe { dma.virt.add(i * entry_size) } as usize);
             } else {
                 phys_addresses

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -12,6 +12,7 @@ use std::sync::atomic::{AtomicUsize, Ordering, ATOMIC_USIZE_INIT};
 use std::{ptr, slice};
 
 use libc;
+use IxgbeDevice;
 
 const HUGE_PAGE_BITS: u32 = 21;
 const HUGE_PAGE_SIZE: usize = 1 << HUGE_PAGE_BITS;
@@ -23,61 +24,117 @@ pub struct Dma<T> {
     pub phys: usize,
 }
 
+const VFIO_DMA_MAP_FLAG_READ: u32 = 1;
+const VFIO_DMA_MAP_FLAG_WRITE: u32 = 2;
+const VFIO_IOMMU_MAP_DMA: u64 = 15217;
+
+/* struct vfio_iommu_type1_dma_map, grabbed from linux/vfio.h */
+struct vfio_iommu_type1_dma_map {
+    argsz: u32,
+    flags: u32,
+    vaddr: *mut u8,
+    iova: *mut u8,
+    size: usize,
+}
+
 impl<T> Dma<T> {
     /// Allocates dma memory on a huge page.
-    pub fn allocate(size: usize, require_contigous: bool) -> Result<Dma<T>, Box<Error>> {
+    pub fn allocate(size: usize, require_contigous: bool, dev: *const IxgbeDevice) -> Result<Dma<T>, Box<Error>> {
         let size = if size % HUGE_PAGE_SIZE != 0 {
             ((size >> HUGE_PAGE_BITS) + 1) << HUGE_PAGE_BITS
         } else {
             size
         };
 
-        if require_contigous && size > HUGE_PAGE_SIZE {
-            return Err("could not map physically contigous memory".into());
-        }
+        if unsafe{ (*dev).vfio_cfd } != -1 {
+            // get an anonymous mapped memory space from kernel
+            let ptr = unsafe {
+                libc::mmap(
+                    ptr::null_mut(),
+                    size,
+                    libc::PROT_READ | libc::PROT_WRITE,
+                    libc::MAP_PRIVATE | libc::MAP_ANONYMOUS,
+                    0,
+                    0,
+                ) as *mut T
+            };
 
-        let id = HUGEPAGE_ID.fetch_add(1, Ordering::SeqCst);
-        let path = format!("/mnt/huge/ixy-{}-{}", process::id(), id);
+            // This is the main IOMMU work: IOMMU DMA MAP the memory...
+            if ptr.is_null() {
+                Err("failed to memory map ".into())
+            } else {
+                let iommu_dma_map: vfio_iommu_type1_dma_map =
+                    vfio_iommu_type1_dma_map {
+                        argsz: mem::size_of::<vfio_iommu_type1_dma_map> as u32,
+                        vaddr: ptr as *mut u8,
+                        size: size,
+                        iova: ptr as *mut u8,
+                        flags: VFIO_DMA_MAP_FLAG_READ | VFIO_DMA_MAP_FLAG_WRITE,
+                    };
 
-        match fs::OpenOptions::new()
-            .read(true)
-            .write(true)
-            .create(true)
-            .open(path.clone())
-        {
-            Ok(f) => {
-                let ptr = unsafe {
-                    libc::mmap(
-                        ptr::null_mut(),
-                        size,
-                        libc::PROT_READ | libc::PROT_WRITE,
-                        libc::MAP_SHARED | libc::MAP_HUGETLB,
-                        f.as_raw_fd(),
-                        0,
-                    ) as *mut T
+                let ioctl_result = unsafe {
+                    libc::ioctl((*dev).vfio_cfd, VFIO_IOMMU_MAP_DMA, &iommu_dma_map)
                 };
-
-                if ptr.is_null() {
-                    Err("failed to memory map hugepage - hugepages enabled and free?".into())
-                } else if unsafe { libc::mlock(ptr as *mut libc::c_void, size) } == 0 {
+                if ioctl_result != -1 {
                     let memory = Dma {
-                        virt: ptr,
-                        phys: virt_to_phys(ptr as usize)?,
+                        virt: iommu_dma_map.vaddr as *mut T,
+                        phys: iommu_dma_map.iova as usize,
                     };
 
                     Ok(memory)
                 } else {
-                    Err("failed to memory lock hugepage".into())
+                    Err("There was some problem mapping the DMA memory. Is ulimit set for this user?".into())
                 }
             }
-            Err(ref e) if e.kind() == io::ErrorKind::NotFound => Err(Box::new(io::Error::new(
-                io::ErrorKind::NotFound,
-                format!(
-                    "hugepage {} could not be created - hugepages enabled?",
-                    path
-                ),
-            ))),
-            Err(e) => Err(Box::new(e)),
+        } else {
+
+            if require_contigous && size > HUGE_PAGE_SIZE {
+                return Err("could not map physically contigous memory".into());
+            }
+
+            let id = HUGEPAGE_ID.fetch_add(1, Ordering::SeqCst);
+            let path = format!("/mnt/huge/ixy-{}-{}", process::id(), id);
+
+            match fs::OpenOptions::new()
+                .read(true)
+                .write(true)
+                .create(true)
+                .open(path.clone())
+            {
+                Ok(f) => {
+                    let ptr = unsafe {
+                        libc::mmap(
+                            ptr::null_mut(),
+                            size,
+                            libc::PROT_READ | libc::PROT_WRITE,
+                            libc::MAP_SHARED | libc::MAP_HUGETLB,
+                            f.as_raw_fd(),
+                            0,
+                        ) as *mut T
+                    };
+
+                    if ptr.is_null() {
+                        Err("failed to memory map hugepage - hugepages enabled and free?".into())
+                    } else if unsafe { libc::mlock(ptr as *mut libc::c_void, size) } == 0 {
+                        let memory = Dma {
+                            virt: ptr,
+                            phys: virt_to_phys(ptr as usize)?,
+                        };
+
+                        Ok(memory)
+                    } else {
+                        Err("failed to memory lock hugepage".into())
+                    }
+                }
+                Err(ref e) if e.kind() == io::ErrorKind::NotFound => Err(Box::new(io::Error::new(
+                    io::ErrorKind::NotFound,
+                    format!(
+                        "hugepage {} could not be created - hugepages enabled?",
+                        path
+                    ),
+                ))),
+                Err(e) => Err(Box::new(e)),
+            }
         }
     }
 }
@@ -160,13 +217,13 @@ impl Mempool {
     /// # Panics
     ///
     /// Panics if `size` is not a divisor of the page size.
-    pub fn allocate(entries: usize, size: usize) -> Result<Rc<RefCell<Mempool>>, Box<Error>> {
+    pub fn allocate(entries: usize, size: usize, dev: *const IxgbeDevice) -> Result<Rc<RefCell<Mempool>>, Box<Error>> {
         let entry_size = match size {
             0 => 2048,
             x => x,
         };
 
-        let dma: Dma<u8> = Dma::allocate(entries * entry_size, false)?;
+        let dma: Dma<u8> = Dma::allocate(entries * entry_size, false, dev)?;
         let mut phys_addresses = Vec::with_capacity(entries);
 
         for i in 0..entries {

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -46,7 +46,7 @@ impl<T> Dma<T> {
             size
         };
 
-        if unsafe{ (*dev).vfio_cfd } != -1 {
+        if ! unsafe{ (*dev).iommu } {
             // get an anonymous mapped memory space from kernel
             let ptr = unsafe {
                 libc::mmap(
@@ -73,7 +73,7 @@ impl<T> Dma<T> {
                     };
 
                 let ioctl_result = unsafe {
-                    libc::ioctl((*dev).vfio_cfd, VFIO_IOMMU_MAP_DMA, &iommu_dma_map)
+                    libc::ioctl((*dev).cfd, VFIO_IOMMU_MAP_DMA, &iommu_dma_map)
                 };
                 if ioctl_result != -1 {
                     let memory = Dma {

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -70,7 +70,7 @@ impl<T> Dma<T> {
                 Err("failed to memory map ".into())
             } else {
                 let iommu_dma_map: vfio_iommu_type1_dma_map = vfio_iommu_type1_dma_map {
-                    argsz: mem::size_of::<vfio_iommu_type1_dma_map> as u32,
+                    argsz: mem::size_of::<vfio_iommu_type1_dma_map> as usize as u32,
                     vaddr: ptr as *mut u8,
                     size,
                     iova: ptr as *mut u8,
@@ -78,7 +78,11 @@ impl<T> Dma<T> {
                 };
 
                 let ioctl_result = unsafe {
-                    libc::ioctl(dev.get_vfio_container(), VFIO_IOMMU_MAP_DMA, &iommu_dma_map)
+                    libc::ioctl(
+                        dev.get_vfio_container().unwrap(),
+                        VFIO_IOMMU_MAP_DMA,
+                        &iommu_dma_map,
+                    )
                 };
                 if ioctl_result != -1 {
                     let memory = Dma {

--- a/src/pci.rs
+++ b/src/pci.rs
@@ -16,7 +16,7 @@ pub fn unbind_driver(pci_addr: &str) -> Result<(), Box<Error>> {
         Ok(mut f) => {
             write!(f, "{}", pci_addr)?;
             Ok(())
-        },
+        }
         Err(ref e) if e.kind() == io::ErrorKind::NotFound => Ok(()),
         Err(e) => Err(Box::new(e)),
     }


### PR DESCRIPTION
This branch / pull request makes ixy.rs use the intel(TM) IOMMU and thus makes ixy.rs safe(TM).
Right now it compiles and runs and does *not* make any computers explode (to my knowledge), which is good. The code might be ugly, though, and many unneeded comments and commented-out code fragments are still in there. Also, there are some error-checks missing, still.