### PR TITLE
Remove a redundant &Rc::clone

### DIFF
--- a/src/memory.rs
+++ b/src/memory.rs
@@ -118,14 +118,14 @@ impl Packet {
         addr_virt: *mut u8,
         addr_phys: usize,
         len: usize,
-        pool: &Rc<RefCell<Mempool>>,
+        pool: Rc<RefCell<Mempool>>,
         pool_entry: usize,
     ) -> Packet {
         Packet {
             addr_virt,
             addr_phys,
             len,
-            pool: pool.clone(),
+            pool,
             pool_entry,
         }
     }
@@ -253,7 +253,7 @@ pub fn alloc_pkt(pool: &Rc<RefCell<Mempool>>, size: usize) -> Option<Packet> {
                 p.get_virt_addr(packet),
                 p.get_phys_addr(packet),
                 size,
-                &pool.clone(),
+                pool.clone(),
                 packet,
             ))
         },


### PR DESCRIPTION
An `Rc` instance is always necessary for packet construction, taking it
by value makes this clearer. It is then no longer necessary to put the
argument behin a reference in `alloc_pkt`. This avoid one call to 
`Rc::clone` in total and avoids a reference. Afaik llvm is not yet smart 
enough to fully convert this automatically during optimization passes 
beyond function boundaries. There's some weird interaction 
happening where then a compare and [some more instructions 
remain](https://play.rust-lang.org/?version=stable&mode=release&edition=2018&gist=e3f41f9be35b7493c182dfd58fa349e3). Actual performance results may or may not be unoticable in the end..