### PR TITLE
Make IOMMU great again

### DIFF
--- a/src/memory.rs
+++ b/src/memory.rs
@@ -27,6 +27,7 @@ pub struct Dma<T> {
 const VFIO_DMA_MAP_FLAG_READ: u32 = 1;
 const VFIO_DMA_MAP_FLAG_WRITE: u32 = 2;
 const VFIO_IOMMU_MAP_DMA: u64 = 15217;
+const MAP_HUGE_2MB: i32 = 0x54000000; // 21 << 26
 
 // struct vfio_iommu_type1_dma_map, grabbed from linux/vfio.h
 #[allow(non_camel_case_types)]
@@ -59,7 +60,7 @@ impl<T> Dma<T> {
                     ptr::null_mut(),
                     size,
                     libc::PROT_READ | libc::PROT_WRITE,
-                    libc::MAP_PRIVATE | libc::MAP_ANONYMOUS,
+                    libc::MAP_PRIVATE | libc::MAP_ANONYMOUS | libc::MAP_HUGETLB | MAP_HUGE_2MB,
                     0,
                     0,
                 )


### PR DESCRIPTION
Up to now, using the ixgbe driver with IOMMU / VFIO only used small (4k) pages in the MMU / IOMMU.
With this PR, the driver will now use 2MB ("huge") pages (if the used CPU supports it). This makes the ixgbe driver using IOMMU / VFIO just as fast as the non-IOMMU variant. See attached picture for speeds.
![ixy-rs-iommu-speed](https://user-images.githubusercontent.com/2892593/53549740-4fd25280-3b35-11e9-9a91-6e1f304cd7ab.png)
