### PR TITLE
Add prefetching at the packet struct

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,13 @@ The built binaries are located in `target/release/examples/`.
 
 To build and execute the examples at once see **Usage**.
 
+Usage of sse and prefetching requires `x86` or `x86_64` and `sse` enabled. This
+requires extra buildflags to be passed to `cargo`.
+
+```
+RUSTFLAGS="-C target-cpu=native -C target-feature=+sse" cargo build --release --all-targets
+```
+
 ## Performance
 
 Have a look at our [performance results](https://github.com/ixy-languages/ixy-languages#Performance) in the ixy-languages repository.

--- a/src/ixgbe.rs
+++ b/src/ixgbe.rs
@@ -253,6 +253,9 @@ impl IxyDevice for IxgbeDevice {
                         }
                     };
 
+                    #[cfg(all(any(target_arch="x86", target_arch="x86_64"), target_feature="sse"))]
+                    p.prefetch(Prefetch::Time1);
+
                     buffer.push_back(p);
 
                     unsafe {


### PR DESCRIPTION
Leaves open which level of temporal consistency to use for the access
and exposes an unconditionally avaiable enumeration to differentiate
them (potentially useful should prefetching be available for other
architectures).

This also performs prefetching at level Time1 (per documentation into L2
but not L1) for each received packet when the method is enabled. That
was determined fastest in the test cluster.