### PR TITLE
Unsafe block cleanups

### DIFF
--- a/src/ixgbe.rs
+++ b/src/ixgbe.rs
@@ -206,15 +206,12 @@ impl IxyDevice for IxgbeDevice {
                     // replace currently used buffer with new buffer
                     let buf = mem::replace(&mut queue.bufs_in_use[rx_index], buf);
 
-                    let p = unsafe {
-                        Packet {
-                            addr_virt: pool.get_virt_addr(buf),
-                            addr_phys: pool.get_phys_addr(buf),
-                            len: ptr::read_volatile(&(*desc).wb.upper.length as *const u16)
-                                as usize,
-                            pool: pool.clone(),
-                            pool_entry: buf,
-                        }
+                    let p = Packet {
+                        addr_virt: pool.get_virt_addr(buf),
+                        addr_phys: pool.get_phys_addr(buf),
+                        len: unsafe { ptr::read_volatile(&(*desc).wb.upper.length as *const u16) as usize },
+                        pool: pool.clone(),
+                        pool_entry: buf,
                     };
 
                     #[cfg(all(

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -312,8 +312,8 @@ impl Mempool {
     }
 
     /// Returns a packet to the packet pool.
-    pub(crate) unsafe fn get_virt_addr(&self, id: usize) -> *mut u8 {
-        self.base_addr.add(id * self.entry_size)
+    pub(crate) fn get_virt_addr(&self, id: usize) -> *mut u8 {
+        unsafe { self.base_addr.add(id * self.entry_size) }
     }
 
     /// Returns a packet to the packet pool.

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -317,7 +317,7 @@ impl Mempool {
     }
 
     /// Returns a packet to the packet pool.
-    pub(crate) unsafe fn get_phys_addr(&self, id: usize) -> usize {
+    pub(crate) fn get_phys_addr(&self, id: usize) -> usize {
         self.phys_addresses[id]
     }
 

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -301,26 +301,31 @@ impl Mempool {
         Ok(pool)
     }
 
-    /// Removes a packet from the packet pool and returns it, or [`None`] if the pool is empty.
+    /// Returns the position of a free buffer in the memory pool, or [`None`] if the pool is empty.
     pub(crate) fn alloc_buf(&self) -> Option<usize> {
         self.free_stack.borrow_mut().pop()
     }
 
-    /// Returns a packet to the packet pool.
+    /// Marks a buffer in the memory pool as free.
     pub(crate) fn free_buf(&self, id: usize) {
+        assert!(id < self.num_entries, "buffer outside of memory pool");
+        
         self.free_stack.borrow_mut().push(id);
     }
 
-    /// Returns a packet to the packet pool.
+    /// Returns the virtual address of a buffer from the memory pool.
     pub(crate) fn get_virt_addr(&self, id: usize) -> *mut u8 {
+        assert!(id < self.num_entries, "buffer outside of memory pool");
+        
         unsafe { self.base_addr.add(id * self.entry_size) }
     }
 
-    /// Returns a packet to the packet pool.
+    /// Returns the physical address of a buffer from the memory pool.
     pub(crate) fn get_phys_addr(&self, id: usize) -> usize {
         self.phys_addresses[id]
     }
 
+    /// Returns the size of the buffers in the memory pool.
     pub fn entry_size(&self) -> usize {
         self.entry_size
     }


### PR DESCRIPTION
Safe interfaces over unsafe implementations are preferred to prevent the unsafe annotation from spreading all over the code base. As a small cleanup, make get_phys_addr() and get_virt_addr() functions safe to simplify Packet construction in ixy driver's rx_batch().

No functional changes.