### PR TITLE
Implement Virtio driver, add pcap example, and add ixy-ci config

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,6 +13,12 @@ Vagrant.configure('2') do |config|
     #       For now you can use `sudo brctl stp <virbr> off`
   end
 
+  config.vm.provision 'shell', privileged: false, inline: <<-SHELL
+    sudo apt-get update
+    sudo apt-get install -y curl
+    curl -sSf https://sh.rustup.rs | sh -s -- -y
+  SHELL
+
   # IPs are required but not actually used by the examples
   config.vm.define :pktgen do |config|
     config.vm.network 'private_network', ip: '10.100.1.11', nic_type: 'virtio', virtualbox__intnet: 'ixy_net1',

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,33 @@
+Vagrant.configure('2') do |config|
+  config.vm.box = 'debian/buster64'
+
+  config.vm.provider :virtualbox do |vb|
+    vb.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
+    vb.customize ['modifyvm', :id, '--nicpromisc3', 'allow-all']
+  end
+
+  config.vm.provider :libvirt do |libvirt|
+    # NOTE: Sometimes `./setup-hugetlbfs.sh` hangs; `vagrant ssh`ing into the VM unblocks it somehow.
+    # TODO: Disable STP once https://github.com/vagrant-libvirt/vagrant-libvirt/pull/1038 is merged
+    #       (we don't need it at and it produces some unwanted packets that are captured)
+    #       For now you can use `sudo brctl stp <virbr> off`
+  end
+
+  # IPs are required but not actually used by the examples
+  config.vm.define :pktgen do |config|
+    config.vm.network 'private_network', ip: '10.100.1.11', nic_type: 'virtio', virtualbox__intnet: 'ixy_net1',
+                                         libvirt__network_name: 'ixy_net1', libvirt__dhcp_enabled: false
+  end
+
+  config.vm.define :fwd do |config|
+    config.vm.network 'private_network', ip: '10.100.1.12', nic_type: 'virtio', virtualbox__intnet: 'ixy_net1',
+                                         libvirt__network_name: 'ixy_net1', libvirt__dhcp_enabled: false
+    config.vm.network 'private_network', ip: '10.100.2.11', nic_type: 'virtio', virtualbox__intnet: 'ixy_net2',
+                                         libvirt__network_name: 'ixy_net2', libvirt__dhcp_enabled: false
+  end
+
+  config.vm.define :pcap do |config|
+    config.vm.network 'private_network', ip: '10.100.2.12', nic_type: 'virtio', virtualbox__intnet: 'ixy_net2',
+                                         libvirt__network_name: 'ixy_net2', libvirt__dhcp_enabled: false
+  end
+end

--- a/examples/echoer.rs
+++ b/examples/echoer.rs
@@ -61,11 +61,11 @@ pub fn main() {
             // every second
             if nanos > 1_000_000_000 {
                 dev1.read_stats(&mut dev1_stats);
-                dev1_stats.print_stats_diff(&*dev1, &dev1_stats_old, nanos);
+                dev1_stats.print_stats_diff(&dev1, &dev1_stats_old, nanos);
                 dev1_stats_old = dev1_stats;
 
                 dev2.read_stats(&mut dev2_stats);
-                dev2_stats.print_stats_diff(&*dev2, &dev2_stats_old, nanos);
+                dev2_stats.print_stats_diff(&dev2, &dev2_stats_old, nanos);
                 dev2_stats_old = dev2_stats;
 
                 time = Instant::now();

--- a/examples/forwarder.rs
+++ b/examples/forwarder.rs
@@ -61,11 +61,11 @@ pub fn main() {
             // every second
             if nanos > 1_000_000_000 {
                 dev1.read_stats(&mut dev1_stats);
-                dev1_stats.print_stats_diff(&*dev1, &dev1_stats_old, nanos);
+                dev1_stats.print_stats_diff(&dev1, &dev1_stats_old, nanos);
                 dev1_stats_old = dev1_stats;
 
                 dev2.read_stats(&mut dev2_stats);
-                dev2_stats.print_stats_diff(&*dev2, &dev2_stats_old, nanos);
+                dev2_stats.print_stats_diff(&dev2, &dev2_stats_old, nanos);
                 dev2_stats_old = dev2_stats;
 
                 time = Instant::now();

--- a/examples/generator.rs
+++ b/examples/generator.rs
@@ -3,6 +3,7 @@ use std::env;
 use std::process;
 use std::time::Instant;
 
+use byteorder::{ByteOrder, LittleEndian};
 use ixy::memory::{alloc_pkt_batch, Mempool, Packet};
 use ixy::*;
 
@@ -32,7 +33,7 @@ pub fn main() {
     #[rustfmt::skip]
     let pkt_data = [
         0x01, 0x02, 0x03, 0x04, 0x05, 0x06,         // dst MAC
-        0x11, 0x12, 0x13, 0x14, 0x15, 0x16,         // src MAC
+        0x10, 0x10, 0x10, 0x10, 0x10, 0x10,         // src MAC
         0x08, 0x00,                                 // ether type: IPv4
         0x45, 0x00,                                 // Version, IHL, TOS
         ((PACKET_SIZE - 14) >> 8) as u8,            // ip len excluding ethernet, high byte
@@ -61,7 +62,8 @@ pub fn main() {
             for (i, data) in pkt_data.iter().enumerate() {
                 p[i] = *data;
             }
-            let checksum = calc_ip_checksum(p, 14, 20);
+            let checksum = calc_ipv4_checksum(&p[14..14 + 20]);
+            // Calculated checksum is little-endian; checksum field is big-endian
             p[24] = (checksum >> 8) as u8;
             p[25] = (checksum & 0xff) as u8;
         }
@@ -86,11 +88,11 @@ pub fn main() {
 
         // update sequence number of all packets (and checksum if necessary)
         for p in buffer.iter_mut() {
-            p[PACKET_SIZE - 4] = seq_num;
-            seq_num = (seq_num % std::u8::MAX) + 1;
+            LittleEndian::write_u32(&mut p[(PACKET_SIZE - 4)..], seq_num);
+            seq_num = seq_num.wrapping_add(1);
         }
 
-        dev.tx_batch(0, &mut buffer);
+        dev.tx_batch_busy_wait(0, &mut buffer);
 
         // don't poll the time unnecessarily
         if counter & 0xfff == 0 {
@@ -110,14 +112,35 @@ pub fn main() {
     }
 }
 
-// calculate IP/TCP/UDP checksum
-fn calc_ip_checksum(packet: &mut Packet, offset: usize, len: usize) -> u16 {
+/// Calculates IPv4 header checksum
+fn calc_ipv4_checksum(ipv4_header: &[u8]) -> u16 {
+    assert!(ipv4_header.len() % 2 == 0);
     let mut checksum = 0;
-    for i in 0..len / 2 {
-        checksum += ((u32::from(packet[i + offset])) << 8) + u32::from(packet[i + offset + 1]);
+    for i in 0..ipv4_header.len() / 2 {
+        if i == 5 {
+            // Assume checksum field is set to 0
+            continue;
+        }
+        checksum += (u32::from(ipv4_header[i * 2]) << 8) + u32::from(ipv4_header[i * 2 + 1]);
         if checksum > 0xffff {
-            checksum = (checksum & 0xfff) + 1;
+            checksum = (checksum & 0xffff) + 1;
         }
     }
     !(checksum as u16)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ipv4_checksum() {
+        // Test case from the Wikipedia article "IPv4 header checksum"
+        assert_eq!(
+            calc_ipv4_checksum(
+                b"\x45\x00\x00\x73\x00\x00\x40\x00\x40\x11\xb8\x61\xc0\xa8\x00\x01\xc0\xa8\x00\xc7"
+            ),
+            0xb861
+        );
+    }
 }

--- a/examples/pcap.rs
+++ b/examples/pcap.rs
@@ -47,7 +47,7 @@ pub fn main() -> Result<(), io::Error> {
 
     let mut buffer: VecDeque<Packet> = VecDeque::with_capacity(BATCH_SIZE);
     while n_packets != Some(0) {
-        dev.rx_batch(1, &mut buffer, BATCH_SIZE);
+        dev.rx_batch(0, &mut buffer, BATCH_SIZE);
         let time = SystemTime::now();
         let time = time.duration_since(UNIX_EPOCH).unwrap();
 

--- a/examples/pcap.rs
+++ b/examples/pcap.rs
@@ -1,0 +1,66 @@
+use std::collections::VecDeque;
+use std::fs::File;
+use std::io::{self, Write};
+use std::time::{SystemTime, UNIX_EPOCH};
+use std::{env, process};
+
+use byteorder::{WriteBytesExt, LE};
+use ixy::memory::Packet;
+use ixy::*;
+
+const BATCH_SIZE: usize = 32;
+
+pub fn main() -> Result<(), io::Error> {
+    simple_logger::init().unwrap();
+
+    let mut args = env::args().skip(1);
+
+    let (pci_addr, output_file) = match (args.next(), args.next()) {
+        (Some(pci_addr), Some(output_file)) => (pci_addr, output_file),
+        _ => {
+            eprintln!("Usage: cargo run --example pcap <pci bus id> <output file> [n packets]");
+            process::exit(1);
+        }
+    };
+
+    let mut n_packets: Option<usize> = args
+        .next()
+        .map(|n| n.parse().expect("failed to parse n packets"));
+
+    let mut pcap = File::create(output_file)?;
+
+    // pcap header
+    pcap.write_u32::<LE>(0xa1b2_c3d4)?; // magic_number
+    pcap.write_u16::<LE>(2)?; // version_major
+    pcap.write_u16::<LE>(4)?; // version_minor
+    pcap.write_i32::<LE>(0)?; // thiszone
+    pcap.write_u32::<LE>(0)?; // sigfigs
+    pcap.write_u32::<LE>(65535)?; // snaplen
+    pcap.write_u32::<LE>(1)?; // network: Ethernet
+
+    let mut dev = ixy_init(&pci_addr, 1, 1).unwrap();
+
+    let mut buffer: VecDeque<Packet> = VecDeque::with_capacity(BATCH_SIZE);
+    while n_packets != Some(0) {
+        dev.rx_batch(1, &mut buffer, BATCH_SIZE);
+        for packet in buffer.drain(..) {
+            let time = SystemTime::now();
+            let time = time.duration_since(UNIX_EPOCH).unwrap();
+
+            // pcap record header
+            pcap.write_u32::<LE>(time.as_secs() as u32)?; // ts_sec
+            pcap.write_u32::<LE>(time.subsec_millis())?; // ts_usec
+            pcap.write_u32::<LE>(packet.len() as u32)?; // incl_len
+            pcap.write_u32::<LE>(packet.len() as u32)?; // orig_len
+
+            pcap.write_all(&packet)?;
+
+            n_packets = n_packets.map(|n| n - 1);
+            if n_packets == Some(0) {
+                break;
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/examples/pcap.rs
+++ b/examples/pcap.rs
@@ -26,6 +26,11 @@ pub fn main() -> Result<(), io::Error> {
     let mut n_packets: Option<usize> = args
         .next()
         .map(|n| n.parse().expect("failed to parse n packets"));
+    if let Some(n) = n_packets {
+        println!("Capturing {} packets...", n);
+    } else {
+        println!("Capturing packets...");
+    }
 
     let mut pcap = File::create(output_file)?;
 

--- a/examples/pcap.rs
+++ b/examples/pcap.rs
@@ -48,10 +48,10 @@ pub fn main() -> Result<(), io::Error> {
     let mut buffer: VecDeque<Packet> = VecDeque::with_capacity(BATCH_SIZE);
     while n_packets != Some(0) {
         dev.rx_batch(1, &mut buffer, BATCH_SIZE);
-        for packet in buffer.drain(..) {
-            let time = SystemTime::now();
-            let time = time.duration_since(UNIX_EPOCH).unwrap();
+        let time = SystemTime::now();
+        let time = time.duration_since(UNIX_EPOCH).unwrap();
 
+        for packet in buffer.drain(..) {
             // pcap record header
             pcap.write_u32::<LE>(time.as_secs() as u32)?; // ts_sec
             pcap.write_u32::<LE>(time.subsec_millis())?; // ts_usec

--- a/ixy-ci.toml
+++ b/ixy-ci.toml
@@ -1,5 +1,5 @@
 build = [
-    "sudo apt install -y curl gcc",
+    "sudo apt-get install -y curl gcc",
     "curl -sSf https://sh.rustup.rs | sh -s -- -y",
     "source $HOME/.cargo/env && cargo build --release --examples",
     "sudo ./setup-hugetlbfs.sh",

--- a/ixy-ci.toml
+++ b/ixy-ci.toml
@@ -1,0 +1,10 @@
+build = [
+    "sudo apt install -y curl gcc",
+    "curl -sSf https://sh.rustup.rs | sh -s -- -y",
+    "source $HOME/.cargo/env && cargo build --release --examples",
+    "sudo ./setup-hugetlbfs.sh",
+]
+
+pktgen = "target/release/examples/generator $PCI_ADDR_PKTGEN"
+fwd = "target/release/examples/forwarder $PCI_ADDR_FWD_SRC $PCI_ADDR_FWD_DST"
+pcap = "target/release/examples/pcap $PCI_ADDR_PCAP $PCAP_OUT $PCAP_N"

--- a/src/ixgbe.rs
+++ b/src/ixgbe.rs
@@ -183,7 +183,7 @@ impl IxyDevice for IxgbeDevice {
         let mut received_packets = 0;
 
         {
-            let queue = &mut self.rx_queues[queue_id as usize];
+            let queue = self.rx_queues.get_mut(queue_id as usize).expect("invalid rx queue id");
 
             rx_index = queue.rx_index;
             last_rx_index = queue.rx_index;
@@ -257,7 +257,7 @@ impl IxyDevice for IxgbeDevice {
         let mut sent = 0;
 
         {
-            let mut queue = &mut self.tx_queues[queue_id as usize];
+            let mut queue = self.tx_queues.get_mut(queue_id as usize).expect("invalid tx queue id");
 
             let mut cur_index = queue.tx_index;
             let clean_index = clean_tx_queue(&mut queue);

--- a/src/ixgbe.rs
+++ b/src/ixgbe.rs
@@ -337,7 +337,7 @@ impl IxyDevice for IxgbeDevice {
     }
 
     /// Resets the stats of this device.
-    fn reset_stats(&self) {
+    fn reset_stats(&mut self) {
         self.get_reg32(IXGBE_GPRC);
         self.get_reg32(IXGBE_GPTC);
         self.get_reg32(IXGBE_GORCL);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -214,7 +214,7 @@ pub fn ixy_init(
     }
 
     if vendor_id == 0x1af4 && device_id == 0x1000 {
-        // `vendor_id == 0x1041` would be for non-transitional devices which we don't support atm
+        // `device_id == 0x1041` would be for non-transitional devices which we don't support atm
         let device = VirtioDevice::init(pci_addr, rx_queues, tx_queues)?;
         Ok(Box::new(device))
     } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,7 +114,7 @@ pub trait IxyDevice {
     /// let mut dev = ixy_init("0000:01:00.0", 1, 1).unwrap();
     /// dev.reset_stats();
     /// ```
-    fn reset_stats(&self);
+    fn reset_stats(&mut self);
 
     /// Returns the network card's link speed.
     ///
@@ -260,7 +260,7 @@ impl IxyDevice for Box<dyn IxyDevice> {
         (**self).read_stats(stats)
     }
 
-    fn reset_stats(&self) {
+    fn reset_stats(&mut self) {
         (**self).reset_stats()
     }
 

--- a/src/virtio.rs
+++ b/src/virtio.rs
@@ -242,12 +242,11 @@ impl IxyDevice for VirtioDevice {
                 continue;
             }
 
-            let mut buf = memory::alloc_pkt(
+            let buf = memory::alloc_pkt(
                 &self.rx_mempool,
                 self.rx_mempool.entry_size() - PACKET_HEADROOM,
             )
             .expect("rx memory pool exhausted");
-            buf.len = self.rx_mempool.entry_size();
 
             *desc = VirtqDesc {
                 len: buf.len as u32 + mem::size_of::<virtio_net_hdr>() as u32,

--- a/src/virtio.rs
+++ b/src/virtio.rs
@@ -172,7 +172,7 @@ impl IxyDevice for VirtioDevice {
     }
 
     fn get_vfio_container(&self) -> Option<RawFd> {
-        panic!("VFIO isn't supported for Virtio");
+        None
     }
 
     fn get_pci_addr(&self) -> &str {
@@ -317,7 +317,7 @@ impl IxyDevice for VirtioDevice {
                 next: 0,
             };
 
-            let avail_idx = (self.tx_queue.available.idx.0 + sent) % self.tx_queue.size;
+            let avail_idx = (self.tx_queue.available.idx + Wrapping(sent)).0 % self.tx_queue.size;
             self.tx_queue.available[avail_idx] = idx;
 
             self.tx_bytes += packet.len() as u64;

--- a/src/virtio.rs
+++ b/src/virtio.rs
@@ -1,0 +1,672 @@
+use std::collections::VecDeque;
+use std::error::Error;
+use std::fs::File;
+use std::num::Wrapping;
+use std::ops::{Deref, DerefMut, Index, IndexMut};
+use std::os::unix::io::RawFd;
+use std::rc::Rc;
+use std::sync::atomic::{self, Ordering};
+use std::time::Duration;
+use std::{io, mem, slice, thread};
+
+use crate::memory;
+use crate::memory::{Dma, Packet, PACKET_HEADROOM};
+use crate::pci::{self, read_io16, read_io32, read_io8, write_io16, write_io32, write_io8};
+use crate::virtio_constants::*;
+use crate::{DeviceStats, IxyDevice, Mempool};
+
+// we're currently only supporting legacy Virtio via PCI so this is fixed (4.1.5.1.3.1)
+const QUEUE_ALIGNMENT: usize = 4096;
+
+static NET_HEADER: virtio_net_hdr = virtio_net_hdr {
+    flags: 0,
+    gso_type: VIRTIO_NET_HDR_GSO_NONE,
+    hdr_len: 14 + 20 + 8,
+    // ignored fields
+    csum_offset: 0,
+    csum_start: 0,
+    gso_size: 0,
+};
+
+// NOTE: Currently we only support the legacy interface (device id == 0x1000)
+// NOTE: We currently don't keep track of a "driver ring wrap counter" following upstream ixy
+pub struct VirtioDevice {
+    pci_addr: String,
+    bar0: File,
+
+    rx_queue: Virtqueue,
+    tx_queue: Virtqueue,
+    ctrl_queue: Virtqueue,
+
+    rx_mempool: Rc<Mempool>,
+    // tx buffers are managed by user
+    ctrl_mempool: Rc<Mempool>,
+
+    tx_inflight: VecDeque<Packet>,
+    rx_inflight: VecDeque<Packet>,
+
+    // statistics
+    rx_pkts: u64,
+    tx_pkts: u64,
+    rx_bytes: u64,
+    tx_bytes: u64,
+}
+
+impl IxyDevice for VirtioDevice {
+    fn init(
+        pci_addr: &str,
+        num_rx_queues: u16,
+        num_tx_queues: u16,
+    ) -> Result<Self, Box<dyn Error>> {
+        // `getuid()` can't fail according to the man page
+        if unsafe { libc::getuid() } != 0 {
+            warn!("not running as root, this will probably fail");
+        }
+
+        // we don't support multiqueue (VIRTIO_NET_F_MQ)
+        assert!(
+            num_rx_queues <= 1,
+            "cannot configure {} rx queues: limit is {}",
+            num_rx_queues,
+            1
+        );
+        assert!(
+            num_rx_queues <= 1,
+            "cannot configure {} tx queues: limit is {}",
+            num_tx_queues,
+            1
+        );
+
+        pci::unbind_driver(pci_addr)?;
+        pci::enable_dma(pci_addr)?;
+
+        // 3.1: device initialization
+        let mut bar0 = pci::pci_open_resource(pci_addr, "resource0")?;
+        debug!("configuring bar0");
+
+        // 1) Reset the device
+        write_io8(&mut bar0, VIRTIO_CONFIG_STATUS_RESET, VIRTIO_PCI_STATUS)?;
+        while read_io8(&mut bar0, VIRTIO_PCI_STATUS)? != VIRTIO_CONFIG_STATUS_RESET {
+            thread::sleep(Duration::from_micros(100));
+        }
+
+        // 2) Set ACKNOWLEDGE status bit; OS noticed the device
+        write_io8(&mut bar0, VIRTIO_CONFIG_STATUS_ACK, VIRTIO_PCI_STATUS)?;
+
+        // 3) Set DRIVER status bit; OS can drive the device
+        write_io8(&mut bar0, VIRTIO_CONFIG_STATUS_DRIVER, VIRTIO_PCI_STATUS)?;
+
+        // 4) Negotiate features
+        let host_features = read_io32(&mut bar0, VIRTIO_PCI_HOST_FEATURES)?;
+        debug!("device features: {:b}", host_features);
+        let required_features = (1 << VIRTIO_NET_F_CSUM) // we may offload checksumming to the device
+            | (1 << VIRTIO_NET_F_GUEST_CSUM) // we can handle packets with invalid checksums
+            | (1 << VIRTIO_NET_F_CTRL_VQ) // enable the control queue
+            | (1 << VIRTIO_NET_F_CTRL_RX) // required to enable promiscuous mode
+            | (1 << VIRTIO_NET_F_MAC) // required to read MAC address
+            | (1 << VIRTIO_F_ANY_LAYOUT); // we don't make assumptions about message framing
+        if (host_features & required_features) != required_features {
+            debug!("device features:   {:032b}", host_features);
+            debug!("required features: {:032b}", required_features);
+            panic!("device does not support all required features");
+        }
+        debug!(
+            "guest features before negotiation: {:032b}",
+            read_io32(&mut bar0, VIRTIO_PCI_GUEST_FEATURES)?
+        );
+        write_io32(&mut bar0, required_features, VIRTIO_PCI_GUEST_FEATURES)?;
+        debug!(
+            "guest features after negotiation:  {:032b}",
+            read_io32(&mut bar0, VIRTIO_PCI_GUEST_FEATURES)?
+        );
+
+        // 5) Skipped due to legacy interface
+        // 6) Skipped due to legacy interface
+
+        // 7) Perform network device specific initialization
+        let rx_queue = Self::setup_virtqueue(&mut bar0, VirtqueueType::Receive, 0)?;
+        let tx_queue = Self::setup_virtqueue(&mut bar0, VirtqueueType::Transmit, 1)?;
+        let ctrl_queue = Self::setup_virtqueue(&mut bar0, VirtqueueType::Control, 2)?;
+
+        // 2.6.13: allocate buffers to send to the device
+        // we allocate more bufs than what would fit in the rx queue, because we don't want to
+        // stall rx if users hold buffers for longer
+        let rx_mempool = Mempool::allocate(rx_queue.size as usize * 4, 2048)?;
+        let ctrl_mempool = Mempool::allocate(ctrl_queue.size as usize, 2048)?;
+
+        mfence();
+
+        // 8) Signal OK
+        write_io8(&mut bar0, VIRTIO_CONFIG_STATUS_DRIVER_OK, VIRTIO_PCI_STATUS)?;
+        info!("initialization complete");
+
+        let mut device = VirtioDevice {
+            pci_addr: pci_addr.to_owned(),
+            bar0,
+            rx_inflight: VecDeque::with_capacity(rx_queue.size as usize),
+            tx_inflight: VecDeque::with_capacity(tx_queue.size as usize),
+            rx_queue,
+            tx_queue,
+            ctrl_queue,
+            rx_mempool,
+            ctrl_mempool,
+            rx_pkts: 0,
+            tx_pkts: 0,
+            rx_bytes: 0,
+            tx_bytes: 0,
+        };
+
+        // recheck status
+        device.check_pci_config_status()?;
+        device.set_promiscuous(true)?;
+
+        Ok(device)
+    }
+
+    fn get_driver_name(&self) -> &str {
+        "ixy-virtio"
+    }
+
+    fn is_card_iommu_capable(&self) -> bool {
+        false
+    }
+
+    fn get_vfio_container(&self) -> Option<RawFd> {
+        panic!("VFIO isn't supported for Virtio");
+    }
+
+    fn get_pci_addr(&self) -> &str {
+        &self.pci_addr
+    }
+
+    fn get_mac_addr(&self) -> [u8; 6] {
+        let mut bar0 = self.bar0.try_clone().unwrap();
+        let mut mac = [0; 6];
+        for (i, byte) in mac.iter_mut().enumerate() {
+            *byte = read_io8(&mut bar0, (20 + i) as u64).unwrap();
+        }
+        mac
+    }
+
+    fn set_mac_addr(&self, mac: [u8; 6]) {
+        // since we're using the legacy interface we can update the MAC address without having
+        // negotiated `VIRTIO_NET_F_CTRL_MAC_ADDR` during initialization
+        let mut bar0 = self.bar0.try_clone().unwrap();
+        for (i, byte) in mac.iter().enumerate() {
+            write_io8(&mut bar0, *byte, (20 + i) as u64).unwrap();
+        }
+    }
+
+    fn rx_batch(
+        &mut self,
+        _queue_id: u32,
+        buffer: &mut VecDeque<Packet>,
+        num_packets: usize,
+    ) -> usize {
+        // 2.6.14
+
+        mfence();
+        // remove received packets from the virtqueue and make them available to the user
+        for _ in 0..num_packets {
+            if self.rx_queue.last_used_idx == self.rx_queue.used.idx {
+                break;
+            }
+
+            let used =
+                &self.rx_queue.used[self.rx_queue.last_used_idx.0 % self.rx_queue.size].clone();
+            self.rx_queue.last_used_idx += Wrapping(1);
+
+            // mark used descriptor as unused again
+            let desc = &mut self.rx_queue.descriptors_mut()[used.id as usize];
+            assert_eq!(
+                desc.flags, VIRTQ_DESC_F_WRITE,
+                "unsupported flags on rx descriptor: {:x}",
+                desc.flags
+            );
+            desc.addr = 0;
+
+            let mut buf = self.rx_inflight.pop_front().unwrap();
+            // adjust buffer length to actual packet size
+            buf.len = used.len as usize - mem::size_of::<virtio_net_hdr>();
+
+            self.rx_bytes += buf.len as u64;
+            self.rx_pkts += 1;
+            buffer.push_back(buf);
+        }
+
+        // add new descriptors to the available ring so the device can fill those up
+        let mut queued = 0;
+        for idx in 0..self.rx_queue.size {
+            let desc = &mut self.rx_queue.descriptors_mut()[idx as usize];
+            if desc.addr != 0 {
+                continue;
+            }
+
+            let mut buf = memory::alloc_pkt(
+                &self.rx_mempool,
+                self.rx_mempool.entry_size() - PACKET_HEADROOM,
+            )
+            .expect("rx memory pool exhausted");
+            buf.len = self.rx_mempool.entry_size();
+
+            *desc = VirtqDesc {
+                len: buf.len as u32 + mem::size_of::<virtio_net_hdr>() as u32,
+                addr: buf.get_phys_addr() - mem::size_of::<virtio_net_hdr>(),
+                flags: VIRTQ_DESC_F_WRITE,
+                next: 0,
+            };
+
+            let avail_idx = (self.rx_queue.available.idx + Wrapping(queued)).0 % self.rx_queue.size;
+            self.rx_queue.available[avail_idx] = idx;
+
+            queued += 1;
+            self.rx_inflight.push_back(buf);
+        }
+
+        // notify device
+        mfence();
+        self.rx_queue.available.idx += Wrapping(queued);
+        mfence();
+        self.notify_queue(0).expect("notify queue 0 failed");
+
+        buffer.len()
+    }
+
+    fn tx_batch(&mut self, _queue_id: u32, buffer: &mut VecDeque<Packet>) -> usize {
+        // 2.6.13
+
+        mfence();
+        // free all processed packets
+        while self.tx_queue.last_used_idx != self.tx_queue.used.idx {
+            let used_idx =
+                self.tx_queue.used[self.tx_queue.last_used_idx.0 % self.tx_queue.size].id;
+            self.tx_queue.descriptors_mut()[used_idx as usize] = VirtqDesc::default();
+            self.tx_queue.last_used_idx += Wrapping(1);
+            mem::drop(self.tx_inflight.pop_front());
+            mfence();
+        }
+
+        // add user-supplied packets to the available ring for sending out
+        let mut sent = 0;
+        let mut idx = 0;
+        while let Some(mut packet) = buffer.pop_front() {
+            // we cant use `tx_queue.free_descriptor_indices()` here due to borrowck
+            while idx < self.tx_queue.size {
+                let desc = &self.tx_queue.descriptors()[idx as usize];
+                if desc.addr == 0 {
+                    break;
+                }
+                idx += 1;
+            }
+
+            // queue is full; put back the packet we've taken out
+            if idx == self.tx_queue.size {
+                buffer.push_front(packet);
+                break;
+            }
+
+            // Virtio expects a header in front of the actual packet data
+            let net_header = unsafe { any_as_u8_slice(&NET_HEADER) };
+            packet
+                .headroom_mut(net_header.len())
+                .copy_from_slice(net_header);
+
+            self.tx_queue.descriptors_mut()[idx as usize] = VirtqDesc {
+                len: (packet.len() + net_header.len()) as u32,
+                addr: packet.get_phys_addr() - net_header.len(),
+                flags: 0,
+                next: 0,
+            };
+
+            let avail_idx = (self.tx_queue.available.idx.0 + sent) % self.tx_queue.size;
+            self.tx_queue.available[avail_idx] = idx;
+
+            self.tx_bytes += packet.len() as u64;
+            self.tx_pkts += 1;
+
+            sent += 1;
+            self.tx_inflight.push_back(packet);
+        }
+
+        // notify device
+        mfence();
+        self.tx_queue.available.idx += Wrapping(sent);
+        mfence();
+        self.notify_queue(1).expect("notify queue 1 failed");
+
+        sent as usize
+    }
+
+    fn read_stats(&self, stats: &mut DeviceStats) {
+        stats.rx_pkts = self.rx_pkts;
+        stats.tx_pkts = self.tx_pkts;
+        stats.rx_bytes = self.rx_bytes;
+        stats.tx_bytes = self.tx_bytes;
+    }
+
+    fn reset_stats(&mut self) {
+        self.rx_pkts = 0;
+        self.tx_pkts = 0;
+        self.rx_bytes = 0;
+        self.tx_bytes = 0;
+    }
+
+    fn get_link_speed(&self) -> u16 {
+        // Virtio doesn't have a "link speed" per se so we just return something reasonable
+        1000
+    }
+}
+
+impl VirtioDevice {
+    fn notify_queue(&mut self, queue_idx: u16) -> Result<(), io::Error> {
+        write_io16(&mut self.bar0, queue_idx, VIRTIO_PCI_QUEUE_NOTIFY)
+    }
+
+    fn check_pci_config_status(&mut self) -> Result<(), io::Error> {
+        assert_ne!(
+            read_io8(&mut self.bar0, VIRTIO_PCI_STATUS)?,
+            VIRTIO_CONFIG_STATUS_FAILED,
+            "device signaled unrecoverable config error"
+        );
+        Ok(())
+    }
+
+    fn set_promiscuous(&mut self, value: bool) -> Result<(), io::Error> {
+        let command = VirtioNetCtrlPromisc::new(value).into();
+        self.send_command(&command)?;
+        info!("set promiscuous mode to {}", value);
+        Ok(())
+    }
+
+    fn send_command<C: VirtioNetCtrlCommand>(
+        &mut self,
+        command: &VirtioNetCtrl<C>,
+    ) -> Result<(), io::Error> {
+        let cmd_len = mem::size_of::<VirtioNetCtrl<C>>();
+        mfence();
+        let idx = self
+            .ctrl_queue
+            .free_descriptor_indices()
+            .next()
+            .expect("command queue full");
+        debug!(
+            "found free descriptor at index {} (out of {})",
+            idx, self.ctrl_queue.size
+        );
+
+        let mut buf = memory::alloc_pkt(&self.ctrl_mempool, cmd_len).unwrap();
+        buf.copy_from_slice(unsafe { any_as_u8_slice(command) });
+
+        // one descriptor for everything; should work as we negotiated VIRTIO_F_ANY_LAYOUT during
+        // init but doesn't in practice
+        // let desc = &mut ctrl_queue.descriptors_mut()[idx as usize];
+        // desc.len = cmd_len as u32;
+        // desc.addr = buf.get_phys_addr();
+        // desc.flags = VIRTQ_DESC_F_WRITE;
+        // desc.next = 0;
+
+        // device-readable payload: cmd header
+        let desc = &mut self.ctrl_queue.descriptors_mut()[idx as usize];
+        desc.len = 2;
+        desc.addr = buf.get_phys_addr();
+        desc.flags = VIRTQ_DESC_F_NEXT;
+        desc.next = idx + 1;
+        // device-readable payload: cmd data
+        let desc = &mut self.ctrl_queue.descriptors_mut()[(idx + 1) as usize];
+        desc.len = mem::size_of::<C>() as u32;
+        desc.addr = buf.get_phys_addr() + 2;
+        desc.flags = VIRTQ_DESC_F_NEXT;
+        desc.next = idx + 2;
+        // device-writable tail: ack flag
+        let desc = &mut self.ctrl_queue.descriptors_mut()[(idx + 2) as usize];
+        desc.len = 1;
+        desc.addr = buf.get_phys_addr() + 2 + mem::size_of::<C>();
+        desc.flags = VIRTQ_DESC_F_WRITE;
+        desc.next = 0;
+
+        let avail_idx = self.ctrl_queue.available.idx.0 % self.ctrl_queue.size;
+        self.ctrl_queue.available[avail_idx] = idx;
+
+        mfence();
+        self.ctrl_queue.available.idx += Wrapping(1);
+        mfence();
+        self.notify_queue(2)?;
+
+        #[allow(clippy::while_immutable_condition)]
+        while self.ctrl_queue.last_used_idx == self.ctrl_queue.used.idx {
+            mfence();
+            debug!("waiting...");
+            thread::sleep(Duration::from_millis(100));
+        }
+        assert_eq!(
+            (self.ctrl_queue.last_used_idx + Wrapping(1)).0 % self.ctrl_queue.size,
+            self.ctrl_queue.used.idx.0
+        );
+        self.ctrl_queue.last_used_idx = self.ctrl_queue.used.idx;
+
+        let used = &self.ctrl_queue.used[self.ctrl_queue.used.idx.0];
+
+        debug!(
+            "used ctrl buffer @ {:p} id {} len {}",
+            &used, used.id, used.len
+        );
+        assert!(
+            used.id == idx,
+            "used buffer has different index than the one sent"
+        );
+
+        // ensure that the command was correctly acknowledged
+        let ack = unsafe { (*(buf.get_virt_addr() as *const VirtioNetCtrl<C>)).ack };
+        assert_eq!(
+            ack, VIRTIO_NET_OK,
+            "sent command was not acknowledged correctly"
+        );
+
+        Ok(())
+    }
+
+    fn setup_virtqueue(
+        bar0: &mut File,
+        virtq_type: VirtqueueType,
+        index: u16,
+    ) -> Result<Virtqueue, Box<dyn Error>> {
+        assert!(
+            virtq_type.is_valid_index(index),
+            "invalid queue index {} for {:?}",
+            index,
+            virtq_type
+        );
+
+        // 4.1.5.1.3: create virtqueue itself
+        write_io16(bar0, index, VIRTIO_PCI_QUEUE_SEL)?;
+        let max_queue_size = read_io16(bar0, VIRTIO_PCI_QUEUE_NUM)?;
+        debug!(
+            "max queue size of queue #{} ({:?}): {}",
+            index, virtq_type, max_queue_size
+        );
+        assert!(max_queue_size > 0, "queue #{} doesn't exist", index);
+        let virtqueue_mem_size = Virtqueue::size(max_queue_size);
+        let mem: Dma<u8> = Dma::allocate(virtqueue_mem_size, true)?;
+        debug!(
+            "allocated {:#x} bytes for virtqueue at {:p}",
+            virtqueue_mem_size, mem.virt
+        );
+        write_io32(
+            bar0,
+            (mem.phys >> VIRTIO_PCI_QUEUE_ADDR_SHIFT) as u32,
+            VIRTIO_PCI_QUEUE_PFN,
+        )?;
+
+        // DMA memory already follows stricter alignment than `VirtqDesc`
+        #[allow(clippy::cast_ptr_alignment)]
+        let mut virtq = unsafe { Virtqueue::new(max_queue_size, mem.virt as *mut VirtqDesc) };
+        debug!("virtq desc:  {:p}", virtq.desc);
+        debug!("virtq avail: {:p}", virtq.available.ptr);
+        debug!("virtq used:  {:p}", virtq.used.ptr);
+        for i in 0..virtq.size {
+            virtq.descriptors_mut()[i as usize] = VirtqDesc::default();
+            virtq.available[i] = 0;
+            virtq.used[i] = VirtqUsedElem::default();
+        }
+        virtq.available.idx = Wrapping(0);
+        virtq.used.idx = Wrapping(0);
+
+        // optimization hint to not get interrupted when the device consumes a buffer
+        virtq.available.flags = VIRTQ_AVAIL_F_NO_INTERRUPT;
+        virtq.used.flags = 0;
+
+        Ok(virtq)
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum VirtqueueType {
+    Receive,
+    Transmit,
+    Control,
+}
+
+impl VirtqueueType {
+    fn is_valid_index(self, index: u16) -> bool {
+        // we don't support VIRTIO_NET_F_MQ atm so there are only 3 queues
+        let valid = match self {
+            VirtqueueType::Receive => 0,
+            VirtqueueType::Transmit => 1,
+            VirtqueueType::Control => 2,
+        };
+        index == valid
+    }
+}
+
+pub struct Virtqueue {
+    size: u16,
+    desc: *mut VirtqDesc,
+    available: QueueWrapper<VirtqAvail>,
+    used: QueueWrapper<VirtqUsed>,
+    last_used_idx: Wrapping<u16>,
+}
+
+impl Virtqueue {
+    unsafe fn new(size: u16, ptr: *mut VirtqDesc) -> Virtqueue {
+        let size_usize = size as usize;
+        let avail = ptr.wrapping_add(size_usize) as *mut VirtqAvail;
+        let used =
+            align((*avail).ring.as_mut_ptr().wrapping_add(size_usize) as _) as *mut VirtqUsed;
+
+        Virtqueue {
+            size,
+            desc: ptr,
+            available: QueueWrapper { ptr: avail, size },
+            used: QueueWrapper { ptr: used, size },
+            last_used_idx: Wrapping(0),
+        }
+    }
+
+    pub fn descriptors(&self) -> &[VirtqDesc] {
+        unsafe { slice::from_raw_parts(self.desc, self.size as usize) }
+    }
+
+    pub fn descriptors_mut(&mut self) -> &mut [VirtqDesc] {
+        unsafe { slice::from_raw_parts_mut(self.desc, self.size as usize) }
+    }
+
+    pub fn free_descriptor_indices(&self) -> impl Iterator<Item = u16> + '_ {
+        self.descriptors()
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, desc)| {
+                if desc.addr == 0 {
+                    Some(idx as u16)
+                } else {
+                    None
+                }
+            })
+    }
+
+    fn size(queue_size: u16) -> usize {
+        // from 2.6.2
+        let queue_size = queue_size as usize;
+        align(mem::size_of::<VirtqDesc>() * queue_size + mem::size_of::<u16>() * (3 + queue_size))
+            + align(mem::size_of::<u16>() * 3 + mem::size_of::<VirtqUsedElem>() * queue_size)
+    }
+}
+
+struct QueueWrapper<T: Queue> {
+    ptr: *mut T,
+    size: u16,
+}
+
+impl<T: Queue> Index<u16> for QueueWrapper<T> {
+    type Output = <T as Queue>::Element;
+    fn index(&self, idx: u16) -> &Self::Output {
+        assert!(
+            idx < self.size,
+            "index {} is greater than queue size {}",
+            idx,
+            self.size
+        );
+        unsafe { &*self.ring().add(idx as usize) }
+    }
+}
+
+impl<T: Queue> IndexMut<u16> for QueueWrapper<T> {
+    fn index_mut(&mut self, idx: u16) -> &mut Self::Output {
+        assert!(
+            idx < self.size,
+            "index {} is greater than queue size {}",
+            idx,
+            self.size
+        );
+        unsafe { &mut *self.ring_mut().add(idx as usize) }
+    }
+}
+
+impl<T: Queue> Deref for QueueWrapper<T> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        unsafe { &*self.ptr }
+    }
+}
+
+impl<T: Queue> DerefMut for QueueWrapper<T> {
+    fn deref_mut(&mut self) -> &mut T {
+        unsafe { &mut *self.ptr }
+    }
+}
+
+fn mfence() {
+    atomic::fence(Ordering::SeqCst);
+}
+
+fn align(ptr: usize) -> usize {
+    ptr + (ptr as *const u8).align_offset(QUEUE_ALIGNMENT)
+}
+
+// from https://stackoverflow.com/a/42186553
+/// Creates a read-only view into the bytes of any sized type `T`. `T` must not contain
+/// (uninitialized) padding bytes as reading them invokes undefined behavior.
+unsafe fn any_as_u8_slice<T: Sized>(p: &T) -> &[u8] {
+    std::slice::from_raw_parts((p as *const T) as *const u8, std::mem::size_of::<T>())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_align() {
+        // we use a function based on libstd; just checking against the macro from the spec to make
+        // sure we have the same behavior
+        fn align_spec(x: usize) -> usize {
+            (x + (QUEUE_ALIGNMENT - 1)) & !(QUEUE_ALIGNMENT - 1)
+        }
+
+        for i in 0..1_000_000 {
+            let aligned = align(i);
+            assert!(aligned >= i);
+            assert!(aligned - i < QUEUE_ALIGNMENT);
+            assert_eq!(aligned % QUEUE_ALIGNMENT, 0);
+            assert_eq!(aligned, align_spec(i));
+        }
+    }
+}

--- a/src/virtio_constants.rs
+++ b/src/virtio_constants.rs
@@ -1,0 +1,277 @@
+#![allow(dead_code)]
+#![allow(clippy::all)]
+// Copied from the ixy C driver
+// Amended with updates from the newer Virtio spec v1.1
+
+/*-
+ *   BSD LICENSE
+ *
+ *   Copyright(c) 2010-2014 Intel Corporation. All rights reserved.
+ *   All rights reserved.
+ *
+ *   Redistribution and use in source and binary forms, with or without
+ *   modification, are permitted provided that the following conditions
+ *   are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *   OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * VirtIO Header, located in BAR 0.
+ */
+pub const VIRTIO_PCI_HOST_FEATURES: u64 = 0;  /* host's supported features (32bit, RO)*/
+pub const VIRTIO_PCI_GUEST_FEATURES: u64 = 4; /* guest's supported features (32, RW) */
+pub const VIRTIO_PCI_QUEUE_PFN: u64 = 8;      /* physical address of VQ (32, RW) */
+pub const VIRTIO_PCI_QUEUE_NUM: u64 = 12;     /* number of ring entries (16, RO) */
+pub const VIRTIO_PCI_QUEUE_SEL: u64 = 14;     /* current VQ selection (16, RW) */
+pub const VIRTIO_PCI_QUEUE_NOTIFY: u64 = 16;  /* notify host regarding VQ (16, RW) */
+pub const VIRTIO_PCI_STATUS: u64 = 18;        /* device status register (8, RW) */
+pub const VIRTIO_PCI_ISR: u64 = 19;           /* interrupt status register, reading also clears the register (8, RO) */
+/* Only if MSIX is enabled: */
+pub const VIRTIO_MSI_CONFIG_VECTOR: u64 = 20; /* configuration change vector (16, RW) */
+pub const VIRTIO_MSI_QUEUE_VECTOR: u64 = 22;  /* vector for selected VQ notifications (16, RW) */
+
+/* Status byte for guest to report progress. */
+pub const VIRTIO_CONFIG_STATUS_RESET: u8 = 0x00;
+pub const VIRTIO_CONFIG_STATUS_ACK: u8 = 0x01;
+pub const VIRTIO_CONFIG_STATUS_DRIVER: u8 = 0x02;
+pub const VIRTIO_CONFIG_STATUS_DRIVER_OK: u8 = 0x04;
+pub const VIRTIO_CONFIG_STATUS_FEATURES_OK: u8 = 0x08;
+pub const VIRTIO_CONFIG_STATUS_FAILED: u8 = 0x80;
+
+/*
+ * How many bits to shift physical queue address written to QUEUE_PFN.
+ * 12 is historical, and due to x86 page size.
+ */
+pub const VIRTIO_PCI_QUEUE_ADDR_SHIFT: usize = 12;
+
+/* This marks a buffer as continuing via the next field. */
+pub const VIRTQ_DESC_F_NEXT: u16 = 1;
+/* This marks a buffer as write-only (otherwise read-only). */
+pub const VIRTQ_DESC_F_WRITE: u16 = 2;
+/* This means the buffer contains a list of buffer descriptors. */
+pub const VIRTQ_DESC_F_INDIRECT: u16 = 4;
+
+/* The feature bitmap for virtio net */
+pub const VIRTIO_NET_F_CSUM: usize = 0;            /* Host handles pkts w/ partial csum */
+pub const VIRTIO_NET_F_GUEST_CSUM: usize = 1;      /* Guest handles pkts w/ partial csum */
+pub const VIRTIO_NET_F_MTU: usize = 3;             /* Initial MTU advice. */
+pub const VIRTIO_NET_F_MAC: usize = 5;             /* Host has given MAC address. */
+pub const VIRTIO_NET_F_GUEST_TSO4: usize = 7;      /* Guest can handle TSOv4 in. */
+pub const VIRTIO_NET_F_GUEST_TSO6: usize = 8;      /* Guest can handle TSOv6 in. */
+pub const VIRTIO_NET_F_GUEST_ECN: usize = 9;       /* Guest can handle TSO[6] w/ ECN in. */
+pub const VIRTIO_NET_F_GUEST_UFO: usize = 10;      /* Guest can handle UFO in. */
+pub const VIRTIO_NET_F_HOST_TSO4: usize = 11;      /* Host can handle TSOv4 in. */
+pub const VIRTIO_NET_F_HOST_TSO6: usize = 12;      /* Host can handle TSOv6 in. */
+pub const VIRTIO_NET_F_HOST_ECN: usize = 13;       /* Host can handle TSO[6] w/ ECN in. */
+pub const VIRTIO_NET_F_HOST_UFO: usize = 14;       /* Host can handle UFO in. */
+pub const VIRTIO_NET_F_MRG_RXBUF: usize = 15;      /* Host can merge receive buffers. */
+pub const VIRTIO_NET_F_STATUS: usize = 16;         /* virtio_net_config.status available */
+pub const VIRTIO_NET_F_CTRL_VQ: usize = 17;        /* Control channel available */
+pub const VIRTIO_NET_F_CTRL_RX: usize = 18;        /* Control channel RX mode support */
+pub const VIRTIO_NET_F_CTRL_VLAN: usize = 19;      /* Control channel VLAN filtering */
+pub const VIRTIO_NET_F_CTRL_RX_EXTRA: usize = 20;  /* Extra RX mode control support */
+pub const VIRTIO_NET_F_GUEST_ANNOUNCE: usize = 21; /* Guest can announce device on the network */
+pub const VIRTIO_NET_F_MQ: usize = 22;             /* Device supports Receive Flow Steering */
+pub const VIRTIO_NET_F_CTRL_MAC_ADDR: usize = 23;  /* Set MAC address */
+
+/* Do we get callbacks when the ring is completely used, even if we've suppressed them? */
+pub const VIRTIO_F_NOTIFY_ON_EMPTY: usize = 24;
+
+/* Can the device handle any descriptor layout? */
+pub const VIRTIO_F_ANY_LAYOUT: usize = 27;
+
+/* We support indirect buffer descriptors */
+pub const VIRTIO_RING_F_INDIRECT_DESC: usize = 28;
+
+pub const VIRTIO_F_VERSION_1: usize = 32;
+pub const VIRTIO_F_IOMMU_PLATFORM: usize = 33;
+
+
+/**
+ * Control the RX mode, ie. promiscuous, allmulti, etc...
+ * All commands require an "out" sg entry containing a 1 byte
+ * state value, zero = disable, non-zero = enable.  Commands
+ * 0 and 1 are supported with the VIRTIO_NET_F_CTRL_RX feature.
+ * Commands 2-5 are added with VIRTIO_NET_F_CTRL_RX_EXTRA.
+ */
+pub const VIRTIO_NET_CTRL_RX: u8 = 0;
+pub const VIRTIO_NET_CTRL_RX_PROMISC: u8 = 0;
+pub const VIRTIO_NET_CTRL_RX_ALLMULTI: u8 = 1;
+pub const VIRTIO_NET_CTRL_RX_ALLUNI: u8 = 2;
+pub const VIRTIO_NET_CTRL_RX_NOMULTI: u8 = 3;
+pub const VIRTIO_NET_CTRL_RX_NOUNI: u8 = 4;
+pub const VIRTIO_NET_CTRL_RX_NOBCAST: u8 = 5;
+
+pub const VIRTIO_NET_OK: u8 = 0;
+pub const VIRTIO_NET_ERR: u8 = 1;
+
+pub const VIRTIO_MAX_CTRL_DATA: usize = 2048;
+
+/**
+ * This is the first element of the scatter-gather list.  If you don't
+ * specify GSO or CSUM features, you can simply ignore the header.
+ */
+#[repr(C)]
+pub struct virtio_net_hdr {
+    pub flags: u8,
+    pub gso_type: u8,
+    pub hdr_len: u16,     // Ethernet + IP + tcp/udp hdrs
+    pub gso_size: u16,    // Bytes to append to hdr_len per frame
+    pub csum_start: u16,  // Position to start checksumming from
+    pub csum_offset: u16, // Offset after that to place checksum
+}
+
+pub const VIRTIO_NET_HDR_F_NEEDS_CSUM: u8 = 1; /**< Use csum_start,csum_offset*/
+pub const VIRTIO_NET_HDR_F_DATA_VALID: u8 = 2; /**< Checksum is valid */
+
+pub const VIRTIO_NET_HDR_GSO_NONE: u8 = 0;   /**< Not a GSO frame */
+pub const VIRTIO_NET_HDR_GSO_TCPV4: u8 = 1;  /**< GSO frame, IPv4 TCP (TSO) */
+pub const VIRTIO_NET_HDR_GSO_UDP: u8 = 3;    /**< GSO frame, IPv4 UDP (UFO) */
+pub const VIRTIO_NET_HDR_GSO_TCPV6: u8 = 4;  /**< GSO frame, IPv6 TCP */
+pub const VIRTIO_NET_HDR_GSO_ECN: u8 = 0x80; /**< TCP has ECN set */
+
+
+/* The Host uses this in used->flags to advise the Guest: don't kick me
+ * when you add a buffer.  It's unreliable, so it's simply an
+ * optimization.  Guest will still kick if it's out of buffers. */
+pub const VIRTQ_USED_F_NO_NOTIFY: u16 = 1;
+/* The Guest uses this in avail->flags to advise the Host: don't
+ * interrupt me when you consume a buffer.  It's unreliable, so it's
+ * simply an optimization. */
+pub const VIRTQ_AVAIL_F_NO_INTERRUPT: u16 = 1;
+
+
+use std::num::Wrapping;
+
+/* VirtIO ring descriptors: 16 bytes.
+ * These can chain together via "next". */
+#[repr(C)]
+#[derive(Default)]
+pub struct VirtqDesc {
+    pub addr: usize, /* Address (guest-physical). */
+    pub len: u32,    /* Length. */
+    pub flags: u16,  /* The flags as indicated above. */
+    pub next: u16,   /* We chain unused descriptors via this. */
+}
+
+#[repr(C)]
+pub struct VirtqAvail {
+    pub flags: u16,
+    pub idx: Wrapping<u16>,
+    pub ring: [u16; 0],
+}
+
+#[repr(C)]
+pub struct VirtqUsed {
+    pub flags: u16,
+    pub idx: Wrapping<u16>,
+    pub ring: [VirtqUsedElem; 0],
+}
+
+#[repr(C)]
+#[derive(Clone, Default)]
+pub struct VirtqUsedElem {
+    /* Index of start of used descriptor chain. */
+    pub id: u16,
+    pub _padding: u16,
+    /* Total length of the descriptor chain which was written to. */
+    pub len: u32,
+}
+
+pub trait Queue {
+    type Element;
+    fn ring(&self) -> *const Self::Element;
+    fn ring_mut(&mut self) -> *mut Self::Element;
+}
+
+impl Queue for VirtqAvail {
+    type Element = u16;
+    fn ring(&self) -> *const u16 {
+        self.ring.as_ptr()
+    }
+    fn ring_mut(&mut self) -> *mut u16 {
+        self.ring.as_mut_ptr()
+    }
+}
+
+impl Queue for VirtqUsed {
+    type Element = VirtqUsedElem;
+    fn ring(&self) -> *const VirtqUsedElem {
+        self.ring.as_ptr()
+    }
+    fn ring_mut(&mut self) -> *mut VirtqUsedElem {
+        self.ring.as_mut_ptr()
+    }
+}
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct VirtioNetCtrl<T: VirtioNetCtrlCommand> {
+    pub class: u8,
+    pub command: u8,
+    pub command_data: T,
+    pub ack: u8,
+}
+
+impl<T: VirtioNetCtrlCommand> From<T> for VirtioNetCtrl<T> {
+    fn from(command_data: T) -> VirtioNetCtrl<T> {
+        VirtioNetCtrl {
+            class: T::CLASS,
+            command: T::COMMAND,
+            command_data,
+            ack: 0,
+        }
+    }
+}
+
+/// A specific command to be sent through the control queue (wrapped in a [`VirtioNetCtrl`])
+pub trait VirtioNetCtrlCommand {
+    const CLASS: u8;
+    const COMMAND: u8;
+}
+
+#[derive(Debug)]
+pub struct VirtioNetCtrlPromisc(u8);
+
+impl VirtioNetCtrlCommand for VirtioNetCtrlPromisc {
+    const CLASS: u8 = VIRTIO_NET_CTRL_RX;
+    const COMMAND: u8 = VIRTIO_NET_CTRL_RX_PROMISC;
+}
+
+impl VirtioNetCtrlPromisc {
+    pub fn new(on: bool) -> VirtioNetCtrlPromisc {
+        VirtioNetCtrlPromisc(on as u8)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::mem;
+    #[test]
+    fn static_type_sizes() {
+        assert_eq!(mem::size_of::<VirtioNetCtrl<VirtioNetCtrlPromisc>>(), 4);
+    }
+}


### PR DESCRIPTION
As stated in the title this adds a Virtio driver to ixy.rs. Also adds everything necessary to test ixy.rs with [ixy-ci](https://github.com/bobo1239/ixy-ci).

The development setup I've used is recorded in the `Vagrantfile`. For now only the [libvirt/qemu provider](https://github.com/vagrant-libvirt/vagrant-libvirt) `vagrant up --provider=libvirt ` should work as VirtualBox doesn't (or at least didn't) support `VIRTIO_F_ANY_LAYOUT`. Support for that can come at a later time...

I've tried to separate some changes into smaller commits so you can hopefully review this more easily.

I'll manually start an ixy-ci run on this PR for demonstration purposes. Later you'll have to add a GitHub webhook for this repository to start test runs.