### PR TITLE
Rename `Queue` trait to `Ring`

### DIFF
--- a/src/ixgbe.rs
+++ b/src/ixgbe.rs
@@ -183,7 +183,10 @@ impl IxyDevice for IxgbeDevice {
         let mut received_packets = 0;
 
         {
-            let queue = self.rx_queues.get_mut(queue_id as usize).expect("invalid rx queue id");
+            let queue = self
+                .rx_queues
+                .get_mut(queue_id as usize)
+                .expect("invalid rx queue id");
 
             rx_index = queue.rx_index;
             last_rx_index = queue.rx_index;
@@ -257,7 +260,10 @@ impl IxyDevice for IxgbeDevice {
         let mut sent = 0;
 
         {
-            let mut queue = self.tx_queues.get_mut(queue_id as usize).expect("invalid tx queue id");
+            let mut queue = self
+                .tx_queues
+                .get_mut(queue_id as usize)
+                .expect("invalid tx queue id");
 
             let mut cur_index = queue.tx_index;
             let clean_index = clean_tx_queue(&mut queue);

--- a/src/virtio.rs
+++ b/src/virtio.rs
@@ -540,8 +540,8 @@ impl VirtqueueType {
 pub struct Virtqueue {
     size: u16,
     desc: *mut VirtqDesc,
-    available: QueueWrapper<VirtqAvail>,
-    used: QueueWrapper<VirtqUsed>,
+    available: RingWrapper<VirtqAvail>,
+    used: RingWrapper<VirtqUsed>,
     last_used_idx: Wrapping<u16>,
 }
 
@@ -555,8 +555,8 @@ impl Virtqueue {
         Virtqueue {
             size,
             desc: ptr,
-            available: QueueWrapper { ptr: avail, size },
-            used: QueueWrapper { ptr: used, size },
+            available: RingWrapper { ptr: avail, size },
+            used: RingWrapper { ptr: used, size },
             last_used_idx: Wrapping(0),
         }
     }
@@ -590,13 +590,13 @@ impl Virtqueue {
     }
 }
 
-struct QueueWrapper<T: Queue> {
+struct RingWrapper<T: Ring> {
     ptr: *mut T,
     size: u16,
 }
 
-impl<T: Queue> Index<u16> for QueueWrapper<T> {
-    type Output = <T as Queue>::Element;
+impl<T: Ring> Index<u16> for RingWrapper<T> {
+    type Output = <T as Ring>::Element;
     fn index(&self, idx: u16) -> &Self::Output {
         assert!(
             idx < self.size,
@@ -608,7 +608,7 @@ impl<T: Queue> Index<u16> for QueueWrapper<T> {
     }
 }
 
-impl<T: Queue> IndexMut<u16> for QueueWrapper<T> {
+impl<T: Ring> IndexMut<u16> for RingWrapper<T> {
     fn index_mut(&mut self, idx: u16) -> &mut Self::Output {
         assert!(
             idx < self.size,
@@ -620,14 +620,14 @@ impl<T: Queue> IndexMut<u16> for QueueWrapper<T> {
     }
 }
 
-impl<T: Queue> Deref for QueueWrapper<T> {
+impl<T: Ring> Deref for RingWrapper<T> {
     type Target = T;
     fn deref(&self) -> &T {
         unsafe { &*self.ptr }
     }
 }
 
-impl<T: Queue> DerefMut for QueueWrapper<T> {
+impl<T: Ring> DerefMut for RingWrapper<T> {
     fn deref_mut(&mut self) -> &mut T {
         unsafe { &mut *self.ptr }
     }

--- a/src/virtio_constants.rs
+++ b/src/virtio_constants.rs
@@ -199,13 +199,13 @@ pub struct VirtqUsedElem {
     pub len: u32,
 }
 
-pub trait Queue {
+pub trait Ring {
     type Element;
     fn ring(&self) -> *const Self::Element;
     fn ring_mut(&mut self) -> *mut Self::Element;
 }
 
-impl Queue for VirtqAvail {
+impl Ring for VirtqAvail {
     type Element = u16;
     fn ring(&self) -> *const u16 {
         self.ring.as_ptr()
@@ -215,7 +215,7 @@ impl Queue for VirtqAvail {
     }
 }
 
-impl Queue for VirtqUsed {
+impl Ring for VirtqUsed {
     type Element = VirtqUsedElem;
     fn ring(&self) -> *const VirtqUsedElem {
         self.ring.as_ptr()


### PR DESCRIPTION
`Ring` makes more sense code-wise (exposes `ring` method) and matches the spec better (e.g. "2.6.6 The Virtqueue Available Ring"). Also fixes formatting in ixgbe.rs which I've forgotten yesterday.