### PR TITLE
Check if IOMMU supports IOVA as VA mode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 libc = "0.2"
 byteorder = "1"
 log = "0.4"
+lazy_static = "1.4.0"
 
 [dev-dependencies]
 simple_logger = "1"

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -74,10 +74,7 @@ impl<T> Dma<T> {
 
             // free unneeded pages (i.e. the additionally mapped 2MB)
             unsafe {
-                libc::munmap(
-                    aligned_addr.offset(-(free_chunk_size as isize)),
-                    free_chunk_size,
-                );
+                libc::munmap(addr, free_chunk_size);
                 libc::munmap(aligned_addr.add(size), HUGE_PAGE_SIZE - free_chunk_size);
             }
 

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -66,13 +66,13 @@ impl<T> Dma<T> {
                 )
             };
 
-            // We calculate the 2MB-aligned address by rounding up
+            // calculate the 2MB-aligned address by rounding up
             let aligned_addr = ((addr as isize + HUGE_PAGE_SIZE as isize - 1)
                 & -(HUGE_PAGE_SIZE as isize)) as *mut libc::c_void;
 
-            // We free unneeded pages (i.e. the additionally mapped 2MB)
             let free_chunk_size = aligned_addr as usize - addr as usize;
 
+            // free unneeded pages (i.e. the additionally mapped 2MB)
             unsafe {
                 libc::munmap(
                     aligned_addr.offset(-(free_chunk_size as isize)),
@@ -81,6 +81,7 @@ impl<T> Dma<T> {
                 libc::munmap(aligned_addr.add(size), HUGE_PAGE_SIZE - free_chunk_size);
             }
 
+            // finally map huge pages at the 2MB-aligned 32-bit address
             let ptr = unsafe {
                 libc::mmap(
                     aligned_addr as *mut libc::c_void,
@@ -99,7 +100,7 @@ impl<T> Dma<T> {
             // This is the main IOMMU work: IOMMU DMA MAP the memory...
             if ptr == libc::MAP_FAILED {
                 Err(format!(
-                    "failed to memory map. Errno: {}",
+                    "failed to memory map DMA-memory. Errno: {}",
                     std::io::Error::last_os_error()
                 )
                 .into())

--- a/src/vfio.rs
+++ b/src/vfio.rs
@@ -118,8 +118,8 @@ pub fn vfio_init(pci_addr: &str) -> Result<RawFd, Box<dyn Error>> {
 
     let gaw = vfio_get_iommu_gaw(pci_addr);
 
-    if IOVA_WIDTH < gaw {
-        warn!("IOMMU supports only {} wide IOVAs, change IOVA_WIDTH in src/memory.rs if DMA mapping fails", gaw);
+    if gaw < IOVA_WIDTH {
+        warn!("IOMMU supports only {} bit wide IOVAs, change IOVA_WIDTH in src/memory.rs if DMA mapping fails!", gaw);
     }
 
     // we also have to build this vfio struct...

--- a/src/vfio.rs
+++ b/src/vfio.rs
@@ -176,12 +176,11 @@ pub fn vfio_init(pci_addr: &str) -> Result<RawFd, Box<dyn Error>> {
 
     // Test the group is viable and available
     if unsafe { libc::ioctl(gfd, VFIO_GROUP_GET_STATUS, &mut group_status) } == -1 {
-        return Err(
-            format!("failed to VFIO_GROUP_GET_STATUS. Errno: {}", unsafe {
-                *libc::__errno_location()
-            })
-            .into(),
-        );
+        return Err(format!(
+            "failed to VFIO_GROUP_GET_STATUS. Errno: {}",
+            std::io::Error::last_os_error()
+        )
+        .into());
     }
     if (group_status.flags & VFIO_GROUP_FLAGS_VIABLE) != 1 {
         return Err(
@@ -297,12 +296,11 @@ pub fn vfio_map_region(fd: RawFd, index: u32) -> Result<(*mut u8, usize), Box<dy
         offset: 0,
     };
     if unsafe { libc::ioctl(fd, VFIO_DEVICE_GET_REGION_INFO, &mut region_info) } == -1 {
-        return Err(
-            format!("failed to VFIO_DEVICE_GET_REGION_INFO. Errno: {}", unsafe {
-                *libc::__errno_location()
-            })
-            .into(),
-        );
+        return Err(format!(
+            "failed to VFIO_DEVICE_GET_REGION_INFO. Errno: {}",
+            std::io::Error::last_os_error()
+        )
+        .into());
     }
 
     let len = region_info.size as usize;

--- a/src/vfio.rs
+++ b/src/vfio.rs
@@ -343,7 +343,11 @@ pub fn vfio_map_dma(ptr: usize, size: usize) -> Result<usize, Box<dyn Error>> {
     if ioctl_result != -1 {
         Ok(iommu_dma_map.iova as usize)
     } else {
-        Err("failed to map the DMA memory - ulimit set for this user?".into())
+        Err(format!(
+            "failed to map the DMA memory (ulimit set?). Errno: {}",
+            std::io::Error::last_os_error()
+        )
+        .into())
     }
 }
 

--- a/src/vfio.rs
+++ b/src/vfio.rs
@@ -119,7 +119,7 @@ pub fn vfio_init(pci_addr: &str) -> Result<RawFd, Box<dyn Error>> {
     let gaw = vfio_get_iommu_gaw(pci_addr);
 
     if gaw < IOVA_WIDTH {
-        warn!("IOMMU supports only {} bit wide IOVAs, change IOVA_WIDTH in src/memory.rs if DMA mapping fails!", gaw);
+        warn!("IOMMU supports only {} bit wide IOVAs, change IOVA_WIDTH in src/memory.rs if DMA mappings fail!", gaw);
     }
 
     // we also have to build this vfio struct...
@@ -360,7 +360,8 @@ pub fn vfio_get_iommu_gaw(pci_addr: &str) -> u8 {
     let iommu_cap = fs::read_to_string(format!(
         "/sys/bus/pci/devices/{}/iommu/intel-iommu/cap",
         pci_addr
-    )).expect("failed to read IOMMU capabilities");
+    ))
+    .expect("failed to read IOMMU capabilities");
 
     let iommu_cap = u64::from_str_radix(&iommu_cap.trim(), 16)
         .expect("failed to convert IOMMU capabilities hex string to u64");

--- a/src/vfio.rs
+++ b/src/vfio.rs
@@ -1,11 +1,13 @@
+#![allow(dead_code)]
+
 use std::error::Error;
 use std::fs;
 use std::fs::{File, OpenOptions};
 use std::mem;
-use std::os::unix::io::{AsRawFd, IntoRawFd, RawFd};
+use std::os::unix::io::{IntoRawFd, RawFd};
 use std::ptr;
 
-use crate::memory::{get_vfio_container, set_vfio_container};
+use crate::memory::{get_vfio_container, set_vfio_container, VFIO_GROUP_FILE_DESCRIPTORS};
 use crate::pci::{BUS_MASTER_ENABLE_BIT, COMMAND_REGISTER_OFFSET};
 
 // constants needed for IOMMU. Grabbed from linux/vfio.h
@@ -112,6 +114,7 @@ pub fn vfio_init(pci_addr: &str) -> Result<RawFd, Box<dyn Error>> {
     let group_file: File;
     let gfd: RawFd;
 
+    /*
     // check supported address width
     let gaw = vfio_get_iommu_gaw(pci_addr);
 
@@ -123,6 +126,7 @@ pub fn vfio_init(pci_addr: &str) -> Result<RawFd, Box<dyn Error>> {
                 .into(),
         );
     }
+    */
 
     // we also have to build this vfio struct...
     let mut group_status: vfio_group_status = vfio_group_status {
@@ -166,35 +170,43 @@ pub fn vfio_init(pci_addr: &str) -> Result<RawFd, Box<dyn Error>> {
         .parse::<i32>()
         .unwrap();
 
-    // open the devices' group
-    group_file = OpenOptions::new()
-        .read(true)
-        .write(true)
-        .open(format!("/dev/vfio/{}", group))
-        .unwrap();
-    gfd = group_file.as_raw_fd();
+    let mut vfio_gfds = VFIO_GROUP_FILE_DESCRIPTORS.lock().unwrap();
 
-    // Test the group is viable and available
-    if unsafe { libc::ioctl(gfd, VFIO_GROUP_GET_STATUS, &mut group_status) } == -1 {
-        return Err(format!(
-            "failed to VFIO_GROUP_GET_STATUS. Errno: {}",
-            std::io::Error::last_os_error()
-        )
-        .into());
-    }
-    if (group_status.flags & VFIO_GROUP_FLAGS_VIABLE) != 1 {
-        return Err(
-            "group is not viable (ie, not all devices in this group are bound to vfio)".into(),
-        );
-    }
+    if !vfio_gfds.contains_key(&group) {
+        // open the devices' group
+        group_file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(format!("/dev/vfio/{}", group))
+            .unwrap();
+        gfd = group_file.into_raw_fd();
 
-    // Add the group to the container
-    if unsafe { libc::ioctl(gfd, VFIO_GROUP_SET_CONTAINER, &cfd) } == -1 {
-        return Err(format!(
-            "failed to VFIO_GROUP_SET_CONTAINER. Errno: {}",
-            std::io::Error::last_os_error()
-        )
-        .into());
+        // Test the group is viable and available
+        if unsafe { libc::ioctl(gfd, VFIO_GROUP_GET_STATUS, &mut group_status) } == -1 {
+            return Err(format!(
+                "failed to VFIO_GROUP_GET_STATUS. Errno: {}",
+                std::io::Error::last_os_error()
+            )
+            .into());
+        }
+        if (group_status.flags & VFIO_GROUP_FLAGS_VIABLE) != 1 {
+            return Err(
+                "group is not viable (ie, not all devices in this group are bound to vfio)".into(),
+            );
+        }
+
+        // Add the group to the container
+        if unsafe { libc::ioctl(gfd, VFIO_GROUP_SET_CONTAINER, &cfd) } == -1 {
+            return Err(format!(
+                "failed to VFIO_GROUP_SET_CONTAINER. Errno: {}",
+                std::io::Error::last_os_error()
+            )
+            .into());
+        }
+
+        vfio_gfds.insert(group, gfd);
+    } else {
+        gfd = *vfio_gfds.get(&group).unwrap();
     }
 
     if first_time_setup {


### PR DESCRIPTION
Add support for older IOMMUs (i.e. IOVA address width 39 bit) and multiple devices in a single IOMMU group