### PR TITLE
Implement ixgbevf

### DIFF
--- a/examples/forwarder.rs
+++ b/examples/forwarder.rs
@@ -89,7 +89,9 @@ fn forward(
     if num_rx > 0 {
         // touch all packets for a realistic workload
         for p in buffer.iter_mut() {
-            p[48] += 1;
+            // we change a byte of the destination MAC address to ensure
+            // that all packets are put back on the link (vital for VFs)
+            p[3] += 1;
         }
 
         tx_dev.tx_batch(tx_queue, buffer);

--- a/examples/generator.rs
+++ b/examples/generator.rs
@@ -32,7 +32,7 @@ pub fn main() {
     let mut dev = ixy_init(&pci_addr, 1, 1, 0).unwrap();
 
     #[rustfmt::skip]
-    let pkt_data = [
+    let mut pkt_data = [
         0x01, 0x02, 0x03, 0x04, 0x05, 0x06,         // dst MAC
         0x10, 0x10, 0x10, 0x10, 0x10, 0x10,         // src MAC
         0x08, 0x00,                                 // ether type: IPv4
@@ -50,6 +50,9 @@ pub fn main() {
         b'i', b'x', b'y'                            // payload
         // rest of the payload is zero-filled because mempools guarantee empty bufs
     ];
+
+    // VFs: src MAC must be MAC of the device (spoof check of PF)
+    pkt_data[6..12].clone_from_slice(&dev.get_mac_addr());
 
     let pool = Mempool::allocate(NUM_PACKETS, 0).unwrap();
 

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -4,11 +4,11 @@
 #![allow(non_upper_case_globals)]
 #![allow(clippy::all)]
 // list of all NIC registers and some structs
-// copied and changed from the ixy C driver
+// copied and changed from the ixy C driver and DPDK
 
 /*******************************************************************************
 
-Copyright (c) 2001-2015, Intel Corporation
+Copyright (c) 2001-2020, Intel Corporation
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -4185,3 +4185,206 @@ pub const IXGBE_NW_MNG_IF_SEL_SGMII_ENABLE: u32                        = 1 << 25
 pub const IXGBE_NW_MNG_IF_SEL_INT_PHY_MODE: u32                        = 1 << 24; /* X552 reg field only */
 pub const IXGBE_NW_MNG_IF_SEL_MDIO_PHY_ADD_SHIFT: u32                  = 3;
 pub const IXGBE_NW_MNG_IF_SEL_MDIO_PHY_ADD: u32                        = 0x1F << IXGBE_NW_MNG_IF_SEL_MDIO_PHY_ADD_SHIFT;
+
+// Constants and functions for ixgbevf
+
+pub const IXGBE_VF_IRQ_CLEAR_MASK: u32                                 = 7;
+pub const IXGBE_VF_MAX_TX_QUEUES: u32                                  = 8;
+pub const IXGBE_VF_MAX_RX_QUEUES: u32                                  = 8;
+
+/* DCB define */
+pub const IXGBE_VF_MAX_TRAFFIC_CLASS: u32                              = 8;
+
+pub const IXGBE_VFCTRL: u32                                            = 0x00000;
+pub const IXGBE_VFSTATUS: u32                                          = 0x00008;
+pub const IXGBE_VFLINKS: u32                                           = 0x00010;
+pub const IXGBE_VFFRTIMER: u32                                         = 0x00048;
+pub const IXGBE_VFRXMEMWRAP: u32                                       = 0x03190;
+pub const IXGBE_VTEICR: u32                                            = 0x00100;
+pub const IXGBE_VTEICS: u32                                            = 0x00104;
+pub const IXGBE_VTEIMS: u32                                            = 0x00108;
+pub const IXGBE_VTEIMC: u32                                            = 0x0010C;
+pub const IXGBE_VTEIAC: u32                                            = 0x00110;
+pub const IXGBE_VTEIAM: u32                                            = 0x00114;
+
+pub fn IXGBE_VTEITR(x: u32) -> u32 { 0x00820 + 4 * x }
+pub fn IXGBE_VTIVAR(x: u32) -> u32 { 0x00120 + 4 * x }
+pub const IXGBE_VTIVAR_MISC: u32                                       = 0x00140;
+pub fn IXGBE_VTRSCINT(x: u32) -> u32 { 0x00180 + 4 * x }
+/* define IXGBE_VFPBACL  still says TBD in EAS */
+pub fn IXGBE_VFRDBAL(x: u32) -> u32 { 0x01000 + 0x40 * x }
+pub fn IXGBE_VFRDBAH(x: u32) -> u32 { 0x01004 + 0x40 * x }
+pub fn IXGBE_VFRDLEN(x: u32) -> u32 { 0x01008 + 0x40 * x }
+pub fn IXGBE_VFRDH(x: u32) -> u32 { 0x01010 + 0x40 * x }
+pub fn IXGBE_VFRDT(x: u32) -> u32 { 0x01018 + 0x40 * x }
+pub fn IXGBE_VFRXDCTL(x: u32) -> u32 { 0x01028 + 0x40 * x }
+pub fn IXGBE_VFSRRCTL(x: u32) -> u32 { 0x01014 + 0x40 * x }
+pub fn IXGBE_VFRSCCTL(x: u32) -> u32 { 0x0102C + 0x40 * x }
+pub const IXGBE_VFPSRTYPE: u32                                         = 0x00300;
+pub fn IXGBE_VFTDBAL(x: u32) -> u32 { 0x02000 + 0x40 * x }
+pub fn IXGBE_VFTDBAH(x: u32) -> u32 { 0x02004 + 0x40 * x }
+pub fn IXGBE_VFTDLEN(x: u32) -> u32 { 0x02008 + 0x40 * x }
+pub fn IXGBE_VFTDH(x: u32) -> u32 { 0x02010 + 0x40 * x }
+pub fn IXGBE_VFTDT(x: u32) -> u32 { 0x02018 + 0x40 * x }
+pub fn IXGBE_VFTXDCTL(x: u32) -> u32 { 0x02028 + 0x40 * x }
+pub fn IXGBE_VFTDWBAL(x: u32) -> u32 { 0x02038 + 0x40 * x }
+pub fn IXGBE_VFTDWBAH(x: u32) -> u32 { 0x0203C + 0x40 * x }
+pub fn IXGBE_VFDCA_RXCTRL(x: u32) -> u32 { 0x0100C + 0x40 * x }
+pub fn IXGBE_VFDCA_TXCTRL(x: u32) -> u32 { 0x0200c + 0x40 * x }
+pub const IXGBE_VFGPRC: u32                                            = 0x0101C;
+pub const IXGBE_VFGPTC: u32                                            = 0x0201C;
+pub const IXGBE_VFGORC_LSB: u32                                        = 0x01020;
+pub const IXGBE_VFGORC_MSB: u32                                        = 0x01024;
+pub const IXGBE_VFGOTC_LSB: u32                                        = 0x02020;
+pub const IXGBE_VFGOTC_MSB: u32                                        = 0x02024;
+pub const IXGBE_VFMPRC: u32                                            = 0x01034;
+pub const IXGBE_VFMRQC: u32                                            = 0x3000;
+pub fn IXGBE_VFRSSRK(x: u32) -> u32 { 0x3100 + x * 4 }
+pub fn IXGBE_VFRETA(x: u32) -> u32 { 0x3200 + x * 4 }
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct ixgbevf_hw_stats {
+    pub base_vfgprc: u64,
+    pub base_vfgptc: u64,
+    pub base_vfgorc: u64,
+    pub base_vfgotc: u64,
+    pub base_vfmprc: u64,
+
+    pub last_vfgprc: u64,
+    pub last_vfgptc: u64,
+    pub last_vfgorc: u64,
+    pub last_vfgotc: u64,
+    pub last_vfmprc: u64,
+
+    pub vfgprc: u64,
+    pub vfgptc: u64,
+    pub vfgorc: u64,
+    pub vfgotc: u64,
+    pub vfmprc: u64,
+
+    pub saved_reset_vfgprc: u64,
+    pub saved_reset_vfgptc: u64,
+    pub saved_reset_vfgorc: u64,
+    pub saved_reset_vfgotc: u64,
+    pub saved_reset_vfmprc: u64,
+}
+
+// Constants and functions for ixgbevf mailbox communication
+
+pub const IXGBE_VFMAILBOX_SIZE: u16                     = 16; /* 16 32 bit words - 64 bytes */
+pub const IXGBE_ERR_MBX: i32                            = -100;
+
+pub const IXGBE_VFMAILBOX: u32                          = 0x002FC;
+pub const IXGBE_VFMBMEM: u32                            = 0x00200;
+
+/* Define mailbox register bits */
+pub const IXGBE_VFMAILBOX_REQ: u32                      = 0x00000001; /* Request for PF Ready bit */
+pub const IXGBE_VFMAILBOX_ACK: u32                      = 0x00000002; /* Ack PF message received */
+pub const IXGBE_VFMAILBOX_VFU: u32                      = 0x00000004; /* VF owns the mailbox buffer */
+pub const IXGBE_VFMAILBOX_PFU: u32                      = 0x00000008; /* PF owns the mailbox buffer */
+pub const IXGBE_VFMAILBOX_PFSTS: u32                    = 0x00000010; /* PF wrote a message in the MB */
+pub const IXGBE_VFMAILBOX_PFACK: u32                    = 0x00000020; /* PF ack the previous VF msg */
+pub const IXGBE_VFMAILBOX_RSTI: u32                     = 0x00000040; /* PF has reset indication */
+pub const IXGBE_VFMAILBOX_RSTD: u32                     = 0x00000080; /* PF has indicated reset done */
+pub const IXGBE_VFMAILBOX_R2C_BITS: u32                 = 0x000000B0; /* All read to clear bits */
+
+pub const IXGBE_PFMAILBOX_STS: u32                      = 0x00000001; /* Initiate message send to VF */
+pub const IXGBE_PFMAILBOX_ACK: u32                      = 0x00000002; /* Ack message recv'd from VF */
+pub const IXGBE_PFMAILBOX_VFU: u32                      = 0x00000004; /* VF owns the mailbox buffer */
+pub const IXGBE_PFMAILBOX_PFU: u32                      = 0x00000008; /* PF owns the mailbox buffer */
+pub const IXGBE_PFMAILBOX_RVFU: u32                     = 0x00000010; /* Reset VFU - used when VF stuck */
+
+pub const IXGBE_MBVFICR_VFREQ_MASK: u32                 = 0x0000FFFF; /* bits for VF messages */
+pub const IXGBE_MBVFICR_VFREQ_VF1: u32                  = 0x00000001; /* bit for VF 1 message */
+pub const IXGBE_MBVFICR_VFACK_MASK: u32                 = 0xFFFF0000; /* bits for VF acks */
+pub const IXGBE_MBVFICR_VFACK_VF1: u32                  = 0x00010000; /* bit for VF 1 ack */
+
+
+/* If it's a IXGBE_VF_* msg then it originates in the VF and is sent to the
+ * PF.  The reverse is true if it is IXGBE_PF_*.
+ * Message ACK's are the value or'd with 0xF0000000
+ */
+pub const IXGBE_VT_MSGTYPE_ACK: u32                     = 0x80000000; /* Messages below or'd with this are the ACK */
+pub const IXGBE_VT_MSGTYPE_NACK: u32                    = 0x40000000; /* Messages below or'd with this are the NACK */
+pub const IXGBE_VT_MSGTYPE_CTS: u32                     = 0x20000000; /* Indicates that VF is still clear to send requests */
+pub const IXGBE_VT_MSGINFO_SHIFT: u32                   = 16;
+/* bits 23:16 are used for extra info for certain messages */
+pub const IXGBE_VT_MSGINFO_MASK: u32                    = 0xFF << IXGBE_VT_MSGINFO_SHIFT;
+
+/* definitions to support mailbox API version negotiation */
+
+/*
+ * each element denotes a version of the API; existing numbers may not
+ * change; any additions must go at the end
+ */
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub enum ixgbe_pfvf_api_rev {
+    ixgbe_mbox_api_10,	/* API version 1.0, linux/freebsd VF driver */
+    ixgbe_mbox_api_20,	/* API version 2.0, solaris Phase1 VF driver */
+    ixgbe_mbox_api_11,	/* API version 1.1, linux/freebsd VF driver */
+    ixgbe_mbox_api_12,	/* API version 1.2, linux/freebsd VF driver */
+    ixgbe_mbox_api_13,	/* API version 1.3, linux/freebsd VF driver */
+    /* This value should always be last */
+    ixgbe_mbox_api_unknown,	/* indicates that API version is not known */
+}
+
+/* mailbox API, legacy requests */
+pub const IXGBE_VF_RESET: u32                           = 0x01; /* VF requests reset */
+pub const IXGBE_VF_SET_MAC_ADDR: u32                    = 0x02; /* VF requests PF to set MAC addr */
+pub const IXGBE_VF_SET_MULTICAST: u32                   = 0x03; /* VF requests PF to set MC addr */
+pub const IXGBE_VF_SET_VLAN: u32                        = 0x04; /* VF requests PF to set VLAN */
+
+/* mailbox API, version 1.0 VF requests */
+pub const IXGBE_VF_SET_LPE: u32                         = 0x05; /* VF requests PF to set VMOLR.LPE */
+pub const IXGBE_VF_SET_MACVLAN: u32                     = 0x06; /* VF requests PF for unicast filter */
+pub const IXGBE_VF_API_NEGOTIATE: u32                   = 0x08; /* negotiate API version */
+
+/* mailbox API, version 1.1 VF requests */
+pub const IXGBE_VF_GET_QUEUES: u32                      = 0x09; /* get queue configuration */
+
+/* mailbox API, version 1.2 VF requests */
+pub const IXGBE_VF_GET_RETA: u32                        = 0x0a;    /* VF request for RETA */
+pub const IXGBE_VF_GET_RSS_KEY: u32                     = 0x0b;    /* get RSS key */
+pub const IXGBE_VF_UPDATE_XCAST_MODE: u32               = 0x0c;
+
+/* mode choices for IXGBE_VF_UPDATE_XCAST_MODE */
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub enum ixgbevf_xcast_modes {
+    IXGBEVF_XCAST_MODE_NONE = 0,
+    IXGBEVF_XCAST_MODE_MULTI,
+    IXGBEVF_XCAST_MODE_ALLMULTI,
+    IXGBEVF_XCAST_MODE_PROMISC,
+}
+
+/* GET_QUEUES return data indices within the mailbox */
+pub const IXGBE_VF_TX_QUEUES: u32                       = 1; /* number of Tx queues supported */
+pub const IXGBE_VF_RX_QUEUES: u32                       = 2; /* number of Rx queues supported */
+pub const IXGBE_VF_TRANS_VLAN: u32                      = 3; /* Indication of port vlan */
+pub const IXGBE_VF_DEF_QUEUE: u32                       = 4; /* Default queue offset */
+
+/* length of permanent address message returned from PF */
+pub const IXGBE_VF_PERMADDR_MSG_LEN: u32                = 4;
+/* word in permanent address message with the current multicast type */
+pub const IXGBE_VF_MC_TYPE_WORD: u32                    = 3;
+
+pub const IXGBE_PF_CONTROL_MSG: u32                     = 0x0100; /* PF control message */
+
+/* mailbox API, version 2.0 VF requests */
+/* the following two constants were already defined earlier */
+// pub const IXGBE_VF_API_NEGOTIATE: u32                = 0x08; /* negotiate API version */
+// pub const IXGBE_VF_GET_QUEUES: u32                   = 0x09; /* get queue configuration */
+pub const IXGBE_VF_ENABLE_MACADDR: u32                  = 0x0A; /* enable MAC address */
+pub const IXGBE_VF_DISABLE_MACADDR: u32                 = 0x0B; /* disable MAC address */
+pub const IXGBE_VF_GET_MACADDRS: u32                    = 0x0C; /* get all configured MAC addrs */
+pub const IXGBE_VF_SET_MCAST_PROMISC: u32               = 0x0D; /* enable multicast promiscuous */
+pub const IXGBE_VF_GET_MTU: u32                         = 0x0E; /* get bounds on MTU */
+pub const IXGBE_VF_SET_MTU: u32                         = 0x0F; /* set a specific MTU */
+
+/* mailbox API, version 2.0 PF requests */
+pub const IXGBE_PF_TRANSPARENT_VLAN: u32                = 0x0101; /* enable transparent vlan */
+
+pub const IXGBE_VF_MBX_INIT_TIMEOUT: u32                = 2000; /* number of retries on mailbox */
+pub const IXGBE_VF_MBX_INIT_DELAY: u32                  = 500;  /* microseconds between retries */

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -133,7 +133,7 @@ pub const IXGBE_I2CCTL_X550: u32                                       = 0x15F5C
 pub const IXGBE_I2CCTL_X550EM_x: u32                                   = IXGBE_I2CCTL_X550;
 pub const IXGBE_I2CCTL_X550EM_a: u32                                   = IXGBE_I2CCTL_X550;
 
-pub fn IXGBE_I2CCTL_BY_MAC(_hw: u32) -> u32 { IXGBE_BY_MAC(_hw, IXGBE_I2CCTL) }
+pub fn IXGBE_I2CCTL_BY_MAC(hw: u32) -> u32 { IXGBE_BY_MAC(hw, IXGBE_I2CCTL) }
 
 pub const IXGBE_PHY_GPIO: u32                                          = 0x00028;
 pub const IXGBE_MAC_GPIO: u32                                          = 0x00030;
@@ -153,7 +153,7 @@ pub const IXGBE_EEC_X550: u32                                          = IXGBE_E
 pub const IXGBE_EEC_X550EM_x: u32                                      = IXGBE_EEC;
 pub const IXGBE_EEC_X550EM_a: u32                                      = 0x15FF8;
 
-pub fn IXGBE_EEC_BY_MAC(_hw: u32) -> u32 { IXGBE_BY_MAC(_hw, IXGBE_EEC) }
+pub fn IXGBE_EEC_BY_MAC(hw: u32) -> u32 { IXGBE_BY_MAC(hw, IXGBE_EEC) }
 
 pub const IXGBE_EERD: u32                                              = 0x10014;
 pub const IXGBE_EEWR: u32                                              = 0x10018;
@@ -164,7 +164,7 @@ pub const IXGBE_FLA_X550: u32                                          = IXGBE_F
 pub const IXGBE_FLA_X550EM_x: u32                                      = IXGBE_FLA;
 pub const IXGBE_FLA_X550EM_a: u32                                      = 0x15F68;
 
-pub fn IXGBE_FLA_BY_MAC(_hw: u32) -> u32 { IXGBE_BY_MAC(_hw, IXGBE_FLA) }
+pub fn IXGBE_FLA_BY_MAC(hw: u32) -> u32 { IXGBE_BY_MAC(hw, IXGBE_FLA) }
 
 pub const IXGBE_EEMNGCTL: u32                                          = 0x10110;
 pub const IXGBE_EEMNGDATA: u32                                         = 0x10114;
@@ -179,7 +179,7 @@ pub const IXGBE_GRC_X550: u32                                          = IXGBE_G
 pub const IXGBE_GRC_X550EM_x: u32                                      = IXGBE_GRC;
 pub const IXGBE_GRC_X550EM_a: u32                                      = 0x15F64;
 
-pub fn IXGBE_GRC_BY_MAC(_hw: u32) -> u32 { IXGBE_BY_MAC(_hw, IXGBE_GRC) }
+pub fn IXGBE_GRC_BY_MAC(hw: u32) -> u32 { IXGBE_BY_MAC(hw, IXGBE_GRC) }
 
 pub const IXGBE_SRAMREL: u32                                           = 0x10210;
 pub const IXGBE_SRAMREL_X540: u32                                      = IXGBE_SRAMREL;
@@ -187,7 +187,7 @@ pub const IXGBE_SRAMREL_X550: u32                                      = IXGBE_S
 pub const IXGBE_SRAMREL_X550EM_x: u32                                  = IXGBE_SRAMREL;
 pub const IXGBE_SRAMREL_X550EM_a: u32                                  = 0x15F6C;
 
-pub fn IXGBE_SRAMREL_BY_MAC(_hw: u32) -> u32 { IXGBE_BY_MAC(_hw, IXGBE_SRAMREL) }
+pub fn IXGBE_SRAMREL_BY_MAC(hw: u32) -> u32 { IXGBE_BY_MAC(hw, IXGBE_SRAMREL) }
 
 pub const IXGBE_PHYDBG: u32                                            = 0x10218;
 
@@ -205,7 +205,7 @@ pub const IXGBE_I2C_CLK_IN_X550: u32                                   = 0x00004
 pub const IXGBE_I2C_CLK_IN_X550EM_x: u32                               = IXGBE_I2C_CLK_IN_X550;
 pub const IXGBE_I2C_CLK_IN_X550EM_a: u32                               = IXGBE_I2C_CLK_IN_X550;
 
-pub fn fnIXGBE_I2C_CLK_IN_BY_MAC(_hw: u32) -> u32 { IXGBE_BY_MAC(_hw, IXGBE_I2C_CLK_IN) }
+pub fn IXGBE_I2C_CLK_IN_BY_MAC(hw: u32) -> u32 { IXGBE_BY_MAC(hw, IXGBE_I2C_CLK_IN) }
 
 pub const IXGBE_I2C_CLK_OUT: u32                                       = 0x00000002;
 pub const IXGBE_I2C_CLK_OUT_X540: u32                                  = IXGBE_I2C_CLK_OUT;
@@ -213,7 +213,7 @@ pub const IXGBE_I2C_CLK_OUT_X550: u32                                  = 0x00000
 pub const IXGBE_I2C_CLK_OUT_X550EM_x: u32                              = IXGBE_I2C_CLK_OUT_X550;
 pub const IXGBE_I2C_CLK_OUT_X550EM_a: u32                              = IXGBE_I2C_CLK_OUT_X550;
 
-pub fn IXGBE_I2C_CLK_OUT_BY_MAC(_hw: u32) -> u32 { IXGBE_BY_MAC(_hw, IXGBE_I2C_CLK_OUT) }
+pub fn IXGBE_I2C_CLK_OUT_BY_MAC(hw: u32) -> u32 { IXGBE_BY_MAC(hw, IXGBE_I2C_CLK_OUT) }
 
 pub const IXGBE_I2C_DATA_IN: u32                                       = 0x00000004;
 pub const IXGBE_I2C_DATA_IN_X540: u32                                  = IXGBE_I2C_DATA_IN;
@@ -221,7 +221,7 @@ pub const IXGBE_I2C_DATA_IN_X550: u32                                  = 0x00001
 pub const IXGBE_I2C_DATA_IN_X550EM_x: u32                              = IXGBE_I2C_DATA_IN_X550;
 pub const IXGBE_I2C_DATA_IN_X550EM_a: u32                              = IXGBE_I2C_DATA_IN_X550;
 
-pub fn IXGBE_I2C_DATA_IN_BY_MAC(_hw: u32) -> u32 { IXGBE_BY_MAC(_hw, IXGBE_I2C_DATA_IN) }
+pub fn IXGBE_I2C_DATA_IN_BY_MAC(hw: u32) -> u32 { IXGBE_BY_MAC(hw, IXGBE_I2C_DATA_IN) }
 
 pub const IXGBE_I2C_DATA_OUT: u32                                      = 0x00000008;
 pub const IXGBE_I2C_DATA_OUT_X540: u32                                 = IXGBE_I2C_DATA_OUT;
@@ -229,7 +229,7 @@ pub const IXGBE_I2C_DATA_OUT_X550: u32                                 = 0x00000
 pub const IXGBE_I2C_DATA_OUT_X550EM_x: u32                             = IXGBE_I2C_DATA_OUT_X550;
 pub const IXGBE_I2C_DATA_OUT_X550EM_a: u32                             = IXGBE_I2C_DATA_OUT_X550;
 
-pub fn IXGBE_I2C_DATA_OUT_BY_MAC(_hw: u32) -> u32 { IXGBE_BY_MAC(_hw, IXGBE_I2C_DATA_OUT) }
+pub fn IXGBE_I2C_DATA_OUT_BY_MAC(hw: u32) -> u32 { IXGBE_BY_MAC(hw, IXGBE_I2C_DATA_OUT) }
 
 pub const IXGBE_I2C_DATA_OE_N_EN: u32                                  = 0;
 pub const IXGBE_I2C_DATA_OE_N_EN_X540: u32                             = IXGBE_I2C_DATA_OE_N_EN;
@@ -237,7 +237,7 @@ pub const IXGBE_I2C_DATA_OE_N_EN_X550: u32                             = 0x00000
 pub const IXGBE_I2C_DATA_OE_N_EN_X550EM_x: u32                         = IXGBE_I2C_DATA_OE_N_EN_X550;
 pub const IXGBE_I2C_DATA_OE_N_EN_X550EM_a: u32                         = IXGBE_I2C_DATA_OE_N_EN_X550;
 
-pub fn IXGBE_I2C_DATA_OE_N_EN_BY_MAC(_hw: u32) -> u32 { IXGBE_BY_MAC(_hw, IXGBE_I2C_DATA_OE_N_EN) }
+pub fn IXGBE_I2C_DATA_OE_N_EN_BY_MAC(hw: u32) -> u32 { IXGBE_BY_MAC(hw, IXGBE_I2C_DATA_OE_N_EN) }
 
 pub const IXGBE_I2C_BB_EN: u32                                         = 0;
 pub const IXGBE_I2C_BB_EN_X540: u32                                    = IXGBE_I2C_BB_EN;
@@ -245,7 +245,7 @@ pub const IXGBE_I2C_BB_EN_X550: u32                                    = 0x00000
 pub const IXGBE_I2C_BB_EN_X550EM_x: u32                                = IXGBE_I2C_BB_EN_X550;
 pub const IXGBE_I2C_BB_EN_X550EM_a: u32                                = IXGBE_I2C_BB_EN_X550;
 
-pub fn IXGBE_I2C_BB_EN_BY_MAC(_hw: u32) -> u32 { IXGBE_BY_MAC(_hw, IXGBE_I2C_BB_EN) }
+pub fn IXGBE_I2C_BB_EN_BY_MAC(hw: u32) -> u32 { IXGBE_BY_MAC(hw, IXGBE_I2C_BB_EN) }
 
 pub const IXGBE_I2C_CLK_OE_N_EN: u32                                   = 0;
 pub const IXGBE_I2C_CLK_OE_N_EN_X540: u32                              = IXGBE_I2C_CLK_OE_N_EN;
@@ -253,7 +253,7 @@ pub const IXGBE_I2C_CLK_OE_N_EN_X550: u32                              = 0x00002
 pub const IXGBE_I2C_CLK_OE_N_EN_X550EM_x: u32                          = IXGBE_I2C_CLK_OE_N_EN_X550;
 pub const IXGBE_I2C_CLK_OE_N_EN_X550EM_a: u32                          = IXGBE_I2C_CLK_OE_N_EN_X550;
 
-pub fn IXGBE_I2C_CLK_OE_N_EN_BY_MAC(_hw: u32) -> u32 { IXGBE_BY_MAC(_hw, IXGBE_I2C_CLK_OE_N_EN) }
+pub fn IXGBE_I2C_CLK_OE_N_EN_BY_MAC(hw: u32) -> u32 { IXGBE_BY_MAC(hw, IXGBE_I2C_CLK_OE_N_EN) }
 
 pub const IXGBE_I2C_CLOCK_STRETCHING_TIMEOUT: u32                      = 500;
 
@@ -275,13 +275,13 @@ pub const IXGBE_EIMC: u32                                              = 0x00888
 pub const IXGBE_EIAC: u32                                              = 0x00810;
 pub const IXGBE_EIAM: u32                                              = 0x00890;
 
-pub fn IXGBE_EICS_EX(_i: u32) -> u32 { 0x00A90 + (_i) * 4 }
+pub fn IXGBE_EICS_EX(i: u32) -> u32 { 0x00A90 + i * 4 }
 
-pub fn IXGBE_EIMS_EX(_i: u32) -> u32 { 0x00AA0 + (_i) * 4 }
+pub fn IXGBE_EIMS_EX(i: u32) -> u32 { 0x00AA0 + i * 4 }
 
-pub fn IXGBE_EIMC_EX(_i: u32) -> u32 { 0x00AB0 + (_i) * 4 }
+pub fn IXGBE_EIMC_EX(i: u32) -> u32 { 0x00AB0 + i * 4 }
 
-pub fn IXGBE_EIAM_EX(_i: u32) -> u32 { 0x00AD0 + (_i) * 4 }
+pub fn IXGBE_EIAM_EX(i: u32) -> u32 { 0x00AD0 + i * 4 }
 /* 82599 EITR is only 12 bits, with the lower 3 always zero */
 /*
  * 82598 EITR is 16 bits but set the limits based on the max
@@ -292,18 +292,18 @@ pub const IXGBE_MIN_INT_RATE: u32                                      = 956;
 pub const IXGBE_MAX_EITR: u32                                          = 0x00000FF8;
 pub const IXGBE_MIN_EITR: u32                                          = 8;
 
-pub fn IXGBE_EITR(_i: u32) -> u32 { if _i <= 23 { 0x00820 + (_i * 4) } else { 0x012300 + ((_i - 24) * 4) } }
+pub fn IXGBE_EITR(i: u32) -> u32 { if i <= 23 { 0x00820 + i * 4 } else { 0x012300 + ((i - 24) * 4) } }
 
 pub const IXGBE_EITR_ITR_INT_MASK: u32                                 = 0x00000FF8;
 pub const IXGBE_EITR_LLI_MOD: u32                                      = 0x00008000;
 pub const IXGBE_EITR_CNT_WDIS: u32                                     = 0x80000000;
 
-pub fn IXGBE_IVAR(_i: u32) -> u32 { 0x00900 + (_i * 4) } /* 24 at 0x900-0x960 */
+pub fn IXGBE_IVAR(i: u32) -> u32 { 0x00900 + i * 4 } /* 24 at 0x900-0x960 */
 pub const IXGBE_IVAR_MISC: u32                                         = 0x00A00; /* misc MSI-X interrupt causes */
 pub const IXGBE_EITRSEL: u32                                           = 0x00894;
 pub const IXGBE_MSIXT: u32                                             = 0x00000; /* MSI-X Table. 0x0000 - 0x01C */
 pub const IXGBE_MSIXPBA: u32                                           = 0x02000; /* MSI-X Pending bit array */
-pub fn IXGBE_PBACL(_i: u32) -> u32 { if _i == 0 { 0x11068 } else { 0x110C0 + (_i * 4) } }
+pub fn IXGBE_PBACL(i: u32) -> u32 { if i == 0 { 0x11068 } else { 0x110C0 + i * 4 } }
 
 pub const IXGBE_GPIE: u32                                              = 0x00898;
 
@@ -313,25 +313,25 @@ pub const IXGBE_FCADBUH: u32                                           = 0x03214
 pub const IXGBE_FCAMACL: u32                                           = 0x04328;
 pub const IXGBE_FCAMACH: u32                                           = 0x0432C;
 
-pub fn IXGBE_FCRTH_82599(_i: u32) -> u32 { 0x03260 + (_i * 4) } /* 8 of these (0-7) */
-pub fn IXGBE_FCRTL_82599(_i: u32) -> u32 { 0x03220 + (_i * 4) } /* 8 of these (0-7) */
+pub fn IXGBE_FCRTH_82599(i: u32) -> u32 { 0x03260 + i * 4 } /* 8 of these (0-7) */
+pub fn IXGBE_FCRTL_82599(i: u32) -> u32 { 0x03220 + i * 4 } /* 8 of these (0-7) */
 pub const IXGBE_PFCTOP: u32                                            = 0x03008;
 
-pub fn IXGBE_FCTTV(_i: u32) -> u32 { 0x03200 + (_i * 4) } /* 4 of these (0-3) */
-pub fn IXGBE_FCRTL(_i: u32) -> u32 { 0x03220 + (_i * 8) } /* 8 of these (0-7) */
-pub fn IXGBE_FCRTH(_i: u32) -> u32 { 0x03260 + (_i * 8) } /* 8 of these (0-7) */
+pub fn IXGBE_FCTTV(i: u32) -> u32 { 0x03200 + i * 4 } /* 4 of these (0-3) */
+pub fn IXGBE_FCRTL(i: u32) -> u32 { 0x03220 + i * 8 } /* 8 of these (0-7) */
+pub fn IXGBE_FCRTH(i: u32) -> u32 { 0x03260 + i * 8 } /* 8 of these (0-7) */
 pub const IXGBE_FCRTV: u32                                             = 0x032A0;
 pub const IXGBE_FCCFG: u32                                             = 0x03D00;
 pub const IXGBE_TFCS: u32                                              = 0x0CE00;
 
 /* Receive DMA Registers */
-pub fn IXGBE_RDBAL(_i: u32) -> u32 { if _i < 64 { 0x01000 + (_i * 0x40) } else { 0x0D000 + ((_i - 64) * 0x40) } }
-pub fn IXGBE_RDBAH(_i: u32) -> u32 { if _i < 64 { 0x01004 + (_i * 0x40) } else { 0x0D004 + ((_i - 64) * 0x40) } }
-pub fn IXGBE_RDLEN(_i: u32) -> u32 { if _i < 64 { 0x01008 + (_i * 0x40) } else { 0x0D008 + ((_i - 64) * 0x40) } }
-pub fn IXGBE_RDH(_i: u32) -> u32 { if _i < 64 { 0x01010 + (_i * 0x40) } else { 0x0D010 + ((_i - 64) * 0x40) } }
-pub fn IXGBE_RDT(_i: u32) -> u32 { if _i < 64 { 0x01018 + (_i * 0x40) } else { 0x0D018 + ((_i - 64) * 0x40) } }
-pub fn IXGBE_RXDCTL(_i: u32) -> u32 { if _i < 64 { 0x01028 + (_i * 0x40) } else { 0x0D028 + ((_i - 64) * 0x40) } }
-pub fn IXGBE_RSCCTL(_i: u32) -> u32 { if _i < 64 { 0x0102C + (_i * 0x40) } else { 0x0D02C + ((_i - 64) * 0x40) } }
+pub fn IXGBE_RDBAL(i: u32) -> u32 { if i < 64 { 0x01000 + i * 0x40 } else { 0x0D000 + ((i - 64) * 0x40) } }
+pub fn IXGBE_RDBAH(i: u32) -> u32 { if i < 64 { 0x01004 + i * 0x40 } else { 0x0D004 + ((i - 64) * 0x40) } }
+pub fn IXGBE_RDLEN(i: u32) -> u32 { if i < 64 { 0x01008 + i * 0x40 } else { 0x0D008 + ((i - 64) * 0x40) } }
+pub fn IXGBE_RDH(i: u32) -> u32 { if i < 64 { 0x01010 + i * 0x40 } else { 0x0D010 + ((i - 64) * 0x40) } }
+pub fn IXGBE_RDT(i: u32) -> u32 { if i < 64 { 0x01018 + i * 0x40 } else { 0x0D018 + ((i - 64) * 0x40) } }
+pub fn IXGBE_RXDCTL(i: u32) -> u32 { if i < 64 { 0x01028 + i * 0x40 } else { 0x0D028 + ((i - 64) * 0x40) } }
+pub fn IXGBE_RSCCTL(i: u32) -> u32 { if i < 64 { 0x0102C + i * 0x40 } else { 0x0D02C + ((i - 64) * 0x40) } }
 
 pub const IXGBE_RSCDBU: u32                                            = 0x03028;
 pub const IXGBE_RDDCC: u32                                             = 0x02F20;
@@ -343,13 +343,13 @@ pub const IXGBE_STARCTRL: u32                                          = 0x03024
  * 16-64 : 0x01014 + n*0x40;
  * 64-127: 0x0D014 + (n-64)*0x40;
  */
-pub fn IXGBE_SRRCTL(_i: u32) -> u32 {
-    if _i <= 15 {
-        return 0x02100 + (_i * 4);
-    } else if _i < 64 {
-        return 0x01014 + (_i * 0x40);
+pub fn IXGBE_SRRCTL(i: u32) -> u32 {
+    if i <= 15 {
+        0x02100 + i * 4
+    } else if i < 64 {
+        0x01014 + i * 0x40
     } else {
-        return 0x0D014 + ((_i - 64) * 0x40);
+        0x0D014 + ((i - 64) * 0x40)
     }
 }
 /*
@@ -358,19 +358,19 @@ pub fn IXGBE_SRRCTL(_i: u32) -> u32 {
  * 16-64 : 0x0100C + n*0x40;
  * 64-127: 0x0D00C + (n-64)*0x40;
  */
-pub fn IXGBE_DCA_RXCTRL(_i: u32) -> u32 {
-    if _i <= 15 {
-        0x02200 + (_i * 4)
-    } else if _i < 64 {
-        0x0100C + (_i * 0x40)
+pub fn IXGBE_DCA_RXCTRL(i: u32) -> u32 {
+    if i <= 15 {
+        0x02200 + i * 4
+    } else if i < 64 {
+        0x0100C + i * 0x40
     } else {
-        0x0D00C + ((_i - 64) * 0x40)
+        0x0D00C + ((i - 64) * 0x40)
     }
 }
 
 pub const IXGBE_RDRXCTL: u32                                           = 0x02F00;
 /* 8 of these 0x03C00 - 0x03C1C */
-pub fn IXGBE_RXPBSIZE(_i: u32) -> u32 { 0x03C00 + (_i * 4) }
+pub fn IXGBE_RXPBSIZE(i: u32) -> u32 { 0x03C00 + i * 4 }
 
 pub const IXGBE_RXCTRL: u32                                            = 0x03000;
 pub const IXGBE_DROPEN: u32                                            = 0x03D04;
@@ -385,97 +385,97 @@ pub const IXGBE_DRECCCTL_DISABLE: u32                                  = 0;
 pub const IXGBE_DRECCCTL2: u32                                         = 0x02F8C;
 
 /* Multicast Table Array - 128 entries */
-pub fn IXGBE_MTA(_i: u32) -> u32 { 0x05200 + ((_i) * 4) }
+pub fn IXGBE_MTA(i: u32) -> u32 { 0x05200 + i * 4 }
 
-pub fn IXGBE_RAL(_i: u32) -> u32 { if _i <= 15 { 0x05400 + (_i * 8) } else { 0x0A200 + (_i * 8) } }
+pub fn IXGBE_RAL(i: u32) -> u32 { if i <= 15 { 0x05400 + i * 8 } else { 0x0A200 + i * 8 } }
 
-pub fn IXGBE_RAH(_i: u32) -> u32 { if _i <= 15 { 0x05404 + (_i * 8) } else { 0x0A204 + (_i * 8) } }
+pub fn IXGBE_RAH(i: u32) -> u32 { if i <= 15 { 0x05404 + i * 8 } else { 0x0A204 + i * 8 } }
 
-pub fn IXGBE_MPSAR_LO(_i: u32) -> u32 { 0x0A600 + ((_i) * 8) }
+pub fn IXGBE_MPSAR_LO(i: u32) -> u32 { 0x0A600 + i * 8 }
 
-pub fn IXGBE_MPSAR_HI(_i: u32) -> u32 { 0x0A604 + ((_i) * 8) }
+pub fn IXGBE_MPSAR_HI(i: u32) -> u32 { 0x0A604 + i * 8 }
 /* Packet split receive type */
-pub fn IXGBE_PSRTYPE(_i: u32) -> u32 { if _i <= 15 { 0x05480 + (_i * 4) } else { 0x0EA00 + (_i * 4) } }
+pub fn IXGBE_PSRTYPE(i: u32) -> u32 { if i <= 15 { 0x05480 + i * 4 } else { 0x0EA00 + i * 4 } }
 /* array of 4096 1-bit vlan filters */
-pub fn IXGBE_VFTA(_i: u32) -> u32 { 0x0A000 + ((_i) * 4) }
+pub fn IXGBE_VFTA(i: u32) -> u32 { 0x0A000 + i * 4 }
 /*array of 4096 4-bit vlan vmdq indices */
-pub fn IXGBE_VFTAVIND(_j: u32, _i: u32) -> u32 { 0x0A200 + ((_j) * 0x200) + ((_i) * 4) }
+pub fn IXGBE_VFTAVIND(j: u32, i: u32) -> u32 { 0x0A200 + j * 0x200 + i * 4 }
 
 pub const IXGBE_FCTRL: u32                                             = 0x05080;
 pub const IXGBE_VLNCTRL: u32                                           = 0x05088;
 pub const IXGBE_MCSTCTRL: u32                                          = 0x05090;
 pub const IXGBE_MRQC: u32                                              = 0x05818;
 
-pub fn IXGBE_SAQF(_i: u32) -> u32 { 0x0E000 + (_i * 4) } /* Source Address Queue Filter */
-pub fn IXGBE_DAQF(_i: u32) -> u32 { 0x0E200 + (_i * 4) } /* Dest. Address Queue Filter */
-pub fn IXGBE_SDPQF(_i: u32) -> u32 { 0x0E400 + (_i * 4) } /* Src Dest. Addr Queue Filter */
-pub fn IXGBE_FTQF(_i: u32) -> u32 { 0x0E600 + (_i * 4) } /* Five Tuple Queue Filter */
-pub fn IXGBE_ETQF(_i: u32) -> u32 { 0x05128 + (_i * 4) } /* EType Queue Filter */
-pub fn IXGBE_ETQS(_i: u32) -> u32 { 0x0EC00 + (_i * 4) } /* EType Queue Select */
+pub fn IXGBE_SAQF(i: u32) -> u32 { 0x0E000 + i * 4 } /* Source Address Queue Filter */
+pub fn IXGBE_DAQF(i: u32) -> u32 { 0x0E200 + i * 4 } /* Dest. Address Queue Filter */
+pub fn IXGBE_SDPQF(i: u32) -> u32 { 0x0E400 + i * 4 } /* Src Dest. Addr Queue Filter */
+pub fn IXGBE_FTQF(i: u32) -> u32 { 0x0E600 + i * 4 } /* Five Tuple Queue Filter */
+pub fn IXGBE_ETQF(i: u32) -> u32 { 0x05128 + i * 4 } /* EType Queue Filter */
+pub fn IXGBE_ETQS(i: u32) -> u32 { 0x0EC00 + i * 4 } /* EType Queue Select */
 pub const IXGBE_SYNQF: u32                                             = 0x0EC30; /* SYN Packet Queue Filter */
 pub const IXGBE_RQTC: u32                                              = 0x0EC70;
 pub const IXGBE_MTQC: u32                                              = 0x08120;
 
-pub fn IXGBE_VLVF(_i: u32) -> u32 { 0x0F100 + ((_i) * 4) }  /* 64 of these (0-63) */
-pub fn IXGBE_VLVFB(_i: u32) -> u32 { 0x0F200 + ((_i) * 4) }  /* 128 of these (0-127) */
-pub fn IXGBE_VMVIR(_i: u32) -> u32 { 0x08000 + ((_i) * 4) }  /* 64 of these (0-63) */
+pub fn IXGBE_VLVF(i: u32) -> u32 { 0x0F100 + i * 4 }  /* 64 of these (0-63) */
+pub fn IXGBE_VLVFB(i: u32) -> u32 { 0x0F200 + i * 4 }  /* 128 of these (0-127) */
+pub fn IXGBE_VMVIR(i: u32) -> u32 { 0x08000 + i * 4 }  /* 64 of these (0-63) */
 pub const IXGBE_PFFLPL: u32                                            = 0x050B0;
 pub const IXGBE_PFFLPH: u32                                            = 0x050B4;
 pub const IXGBE_VT_CTL: u32                                            = 0x051B0;
 
-pub fn IXGBE_PFMAILBOX(_i: u32) -> u32 { 0x04B00 + (4 * (_i)) } /* 64 total */
+pub fn IXGBE_PFMAILBOX(i: u32) -> u32 { 0x04B00 + 4 * i } /* 64 total */
 /* 64 Mailboxes, 16 DW each */
-pub fn IXGBE_PFMBMEM(_i: u32) -> u32 { 0x13000 + (64 * (_i)) }
+pub fn IXGBE_PFMBMEM(i: u32) -> u32 { 0x13000 + 64 * i }
 
-pub fn IXGBE_PFMBICR(_i: u32) -> u32 { 0x00710 + (4 * (_i)) } /* 4 total */
-pub fn IXGBE_PFMBIMR(_i: u32) -> u32 { 0x00720 + (4 * (_i)) } /* 4 total */
-pub fn IXGBE_VFRE(_i: u32) -> u32 { 0x051E0 + ((_i) * 4) }
+pub fn IXGBE_PFMBICR(i: u32) -> u32 { 0x00710 + 4 * i } /* 4 total */
+pub fn IXGBE_PFMBIMR(i: u32) -> u32 { 0x00720 + 4 * i } /* 4 total */
+pub fn IXGBE_VFRE(i: u32) -> u32 { 0x051E0 + i * 4 }
 
-pub fn IXGBE_VFTE(_i: u32) -> u32 { 0x08110 + ((_i) * 4) }
+pub fn IXGBE_VFTE(i: u32) -> u32 { 0x08110 + i * 4 }
 
-pub fn IXGBE_VMECM(_i: u32) -> u32 { 0x08790 + ((_i) * 4) }
+pub fn IXGBE_VMECM(i: u32) -> u32 { 0x08790 + i * 4 }
 
 pub const IXGBE_QDE: u32                                               = 0x2F04;
 
-pub fn IXGBE_VMTXSW(_i: u32) -> u32 { 0x05180 + ((_i) * 4) } /* 2 total */
-pub fn IXGBE_VMOLR(_i: u32) -> u32 { 0x0F000 + ((_i) * 4) } /* 64 total */
-pub fn IXGBE_UTA(_i: u32) -> u32 { 0x0F400 + ((_i) * 4) }
+pub fn IXGBE_VMTXSW(i: u32) -> u32 { 0x05180 + i * 4 } /* 2 total */
+pub fn IXGBE_VMOLR(i: u32) -> u32 { 0x0F000 + i * 4 } /* 64 total */
+pub fn IXGBE_UTA(i: u32) -> u32 { 0x0F400 + i * 4 }
 
-pub fn IXGBE_MRCTL(_i: u32) -> u32 { 0x0F600 + ((_i) * 4) }
+pub fn IXGBE_MRCTL(i: u32) -> u32 { 0x0F600 + i * 4 }
 
-pub fn IXGBE_VMRVLAN(_i: u32) -> u32 { 0x0F610 + ((_i) * 4) }
+pub fn IXGBE_VMRVLAN(i: u32) -> u32 { 0x0F610 + i * 4 }
 
-pub fn IXGBE_VMRVM(_i: u32) -> u32 { 0x0F630 + ((_i) * 4) }
+pub fn IXGBE_VMRVM(i: u32) -> u32 { 0x0F630 + i * 4 }
 
 pub const IXGBE_LVMMC_RX: u32                                          = 0x2FA8;
 pub const IXGBE_LVMMC_TX: u32                                          = 0x8108;
 pub const IXGBE_LMVM_RX: u32                                           = 0x2FA4;
 pub const IXGBE_LMVM_TX: u32                                           = 0x8124;
 
-pub fn IXGBE_WQBR_RX(_i: u32) -> u32 { 0x2FB0 + ((_i) * 4) } /* 4 total */
-pub fn IXGBE_WQBR_TX(_i: u32) -> u32 { 0x8130 + ((_i) * 4) } /* 4 total */
-pub fn IXGBE_L34T_IMIR(_i: u32) -> u32 { 0x0E800 + ((_i) * 4) } /*128 of these (0-127) */
+pub fn IXGBE_WQBR_RX(i: u32) -> u32 { 0x2FB0 + i * 4 } /* 4 total */
+pub fn IXGBE_WQBR_TX(i: u32) -> u32 { 0x8130 + i * 4 } /* 4 total */
+pub fn IXGBE_L34T_IMIR(i: u32) -> u32 { 0x0E800 + i * 4 } /*128 of these (0-127) */
 pub const IXGBE_RXFECCERR0: u32                                        = 0x051B8;
 pub const IXGBE_LLITHRESH: u32                                         = 0x0EC90;
 
-pub fn IXGBE_IMIR(_i: u32) -> u32 { 0x05A80 + ((_i) * 4) }  /* 8 of these (0-7) */
-pub fn IXGBE_IMIREXT(_i: u32) -> u32 { 0x05AA0 + ((_i) * 4) }  /* 8 of these (0-7) */
+pub fn IXGBE_IMIR(i: u32) -> u32 { 0x05A80 + i * 4 }  /* 8 of these (0-7) */
+pub fn IXGBE_IMIREXT(i: u32) -> u32 { 0x05AA0 + i * 4 }  /* 8 of these (0-7) */
 pub const IXGBE_IMIRVP: u32                                            = 0x05AC0;
 pub const IXGBE_VMD_CTL: u32                                           = 0x0581C;
 
-pub fn IXGBE_RETA(_i: u32) -> u32 { 0x05C00 + ((_i) * 4) }  /* 32 of these (0-31) */
-pub fn IXGBE_ERETA(_i: u32) -> u32 { 0x0EE80 + ((_i) * 4) }  /* 96 of these (0-95) */
-pub fn IXGBE_RSSRK(_i: u32) -> u32 { 0x05C80 + ((_i) * 4) }  /* 10 of these (0-9) */
+pub fn IXGBE_RETA(i: u32) -> u32 { 0x05C00 + i * 4 }  /* 32 of these (0-31) */
+pub fn IXGBE_ERETA(i: u32) -> u32 { 0x0EE80 + i * 4 }  /* 96 of these (0-95) */
+pub fn IXGBE_RSSRK(i: u32) -> u32 { 0x05C80 + i * 4 }  /* 10 of these (0-9) */
 
 /* Registers for setting up RSS on X550 with SRIOV;
- * _p - pool number (0..63)
- * _i - index (0..10 for PFVFRSSRK, 0..15 for PFVFRETA)
+ * p - pool number (0..63)
+ * i - index (0..10 for PFVFRSSRK, 0..15 for PFVFRETA)
  */
-pub fn IXGBE_PFVFMRQC(_p: u32) -> u32 { 0x03400 + (_p * 4) }
+pub fn IXGBE_PFVFMRQC(p: u32) -> u32 { 0x03400 + p * 4 }
 
-pub fn IXGBE_PFVFRSSRK(_i: u32, _p: u32) -> u32 { 0x018000 + (_i * 4) + (_p * 0x40) }
+pub fn IXGBE_PFVFRSSRK(i: u32, p: u32) -> u32 { 0x018000 + i * 4 + p * 0x40 }
 
-pub fn IXGBE_PFVFRETA(_i: u32, _p: u32) -> u32 { 0x019000 + (_i * 4) + (_p * 0x40) }
+pub fn IXGBE_PFVFRETA(i: u32, p: u32) -> u32 { 0x019000 + i * 4 + p * 0x40 }
 
 /* Flow Director registers */
 pub const IXGBE_FDIRCTRL: u32                                          = 0x0EE00;
@@ -498,7 +498,7 @@ pub const IXGBE_FDIRMATCH: u32                                         = 0x0EE58
 pub const IXGBE_FDIRMISS: u32                                          = 0x0EE5C;
 
 /* Flow Director Programming registers */
-pub fn IXGBE_FDIRSIPv6(_i: u32) -> u32 { 0x0EE0C + ((_i) * 4) } /* 3 of these (0-2) */
+pub fn IXGBE_FDIRSIPv6(i: u32) -> u32 { 0x0EE0C + i * 4 } /* 3 of these (0-2) */
 pub const IXGBE_FDIRIPSA: u32                                          = 0x0EE18;
 pub const IXGBE_FDIRIPDA: u32                                          = 0x0EE1C;
 pub const IXGBE_FDIRPORT: u32                                          = 0x0EE20;
@@ -507,33 +507,33 @@ pub const IXGBE_FDIRHASH: u32                                          = 0x0EE28
 pub const IXGBE_FDIRCMD: u32                                           = 0x0EE2C;
 
 /* Transmit DMA registers */
-pub fn IXGBE_TDBAL(_i: u32) -> u32 { 0x06000 + ((_i) * 0x40) } /* 32 of them (0-31)*/
-pub fn IXGBE_TDBAH(_i: u32) -> u32 { 0x06004 + ((_i) * 0x40) }
+pub fn IXGBE_TDBAL(i: u32) -> u32 { 0x06000 + i * 0x40 } /* 32 of them (0-31)*/
+pub fn IXGBE_TDBAH(i: u32) -> u32 { 0x06004 + i * 0x40 }
 
-pub fn IXGBE_TDLEN(_i: u32) -> u32 { 0x06008 + ((_i) * 0x40) }
+pub fn IXGBE_TDLEN(i: u32) -> u32 { 0x06008 + i * 0x40 }
 
-pub fn IXGBE_TDH(_i: u32) -> u32 { 0x06010 + ((_i) * 0x40) }
+pub fn IXGBE_TDH(i: u32) -> u32 { 0x06010 + i * 0x40 }
 
-pub fn IXGBE_TDT(_i: u32) -> u32 { 0x06018 + ((_i) * 0x40) }
+pub fn IXGBE_TDT(i: u32) -> u32 { 0x06018 + i * 0x40 }
 
-pub fn IXGBE_TXDCTL(_i: u32) -> u32 { 0x06028 + ((_i) * 0x40) }
+pub fn IXGBE_TXDCTL(i: u32) -> u32 { 0x06028 + i * 0x40 }
 
-pub fn IXGBE_TDWBAL(_i: u32) -> u32 { 0x06038 + ((_i) * 0x40) }
+pub fn IXGBE_TDWBAL(i: u32) -> u32 { 0x06038 + i * 0x40 }
 
-pub fn IXGBE_TDWBAH(_i: u32) -> u32 { 0x0603C + ((_i) * 0x40) }
+pub fn IXGBE_TDWBAH(i: u32) -> u32 { 0x0603C + i * 0x40 }
 
 pub const IXGBE_DTXCTL: u32                                            = 0x07E00;
 
 pub const IXGBE_DMATXCTL: u32                                          = 0x04A80;
 
-pub fn IXGBE_PFVFSPOOF(_i: u32) -> u32 { 0x08200 + ((_i) * 4) } /* 8 of these 0 - 7 */
+pub fn IXGBE_PFVFSPOOF(i: u32) -> u32 { 0x08200 + i * 4 } /* 8 of these 0 - 7 */
 pub const IXGBE_PFDTXGSWC: u32                                         = 0x08220;
 pub const IXGBE_DTXMXSZRQ: u32                                         = 0x08100;
 pub const IXGBE_DTXTCPFLGL: u32                                        = 0x04A88;
 pub const IXGBE_DTXTCPFLGH: u32                                        = 0x04A8C;
 pub const IXGBE_LBDRPEN: u32                                           = 0x0CA00;
 
-pub fn IXGBE_TXPBTHRESH(_i: u32) -> u32 { 0x04950 + ((_i) * 4) } /* 8 of these 0 - 7 */
+pub fn IXGBE_TXPBTHRESH(i: u32) -> u32 { 0x04950 + i * 4 } /* 8 of these 0 - 7 */
 
 pub const IXGBE_DMATXCTL_TE: u32                                       = 0x1; /* Transmit Enable */
 pub const IXGBE_DMATXCTL_NS: u32                                       = 0x2; /* No Snoop LSO hdr buffer */
@@ -552,13 +552,13 @@ pub const IXGBE_SPOOF_ETHERTYPEAS: u32                                 = 0xFF000
 pub const IXGBE_SPOOF_ETHERTYPEAS_SHIFT: u32                           = 16;
 pub const IXGBE_PFVFSPOOF_REG_COUNT: u32                               = 8;
 /* 16 of these (0-15) */
-pub fn IXGBE_DCA_TXCTRL(_i: u32) -> u32 { 0x07200 + ((_i) * 4) }
+pub fn IXGBE_DCA_TXCTRL(i: u32) -> u32 { 0x07200 + i * 4 }
 /* Tx DCA Control register : 128 of these (0-127) */
-pub fn IXGBE_DCA_TXCTRL_82599(_i: u32) -> u32 { 0x0600C + ((_i) * 0x40) }
+pub fn IXGBE_DCA_TXCTRL_82599(i: u32) -> u32 { 0x0600C + i * 0x40 }
 
 pub const IXGBE_TIPG: u32                                              = 0x0CB00;
 
-pub fn IXGBE_TXPBSIZE(_i: u32) -> u32 { 0x0CC00 + ((_i) * 4) } /* 8 of these */
+pub fn IXGBE_TXPBSIZE(i: u32) -> u32 { 0x0CC00 + i * 4 } /* 8 of these */
 pub const IXGBE_MNGTXMAP: u32                                          = 0x0CD10;
 pub const IXGBE_TIPG_FIBER_DEFAULT: u32                                = 3;
 pub const IXGBE_TXPBSIZE_SHIFT: u32                                    = 10;
@@ -584,11 +584,11 @@ pub const IXGBE_VXLANCTRL_ALL_UDPPORT_MASK: u32                        = 0xfffff
 
 pub const IXGBE_VXLANCTRL_GENEVE_UDPPORT_SHIFT: u32                    = 16;
 
-pub fn IXGBE_FHFT(_n: u32) -> u32 { 0x09000 + ((_n) * 0x100) } /* Flex host filter table */
+pub fn IXGBE_FHFT(n: u32) -> u32 { 0x09000 + n * 0x100 } /* Flex host filter table */
 /* Ext Flexible Host Filter Table */
-pub fn IXGBE_FHFT_EXT(_n: u32) -> u32 { 0x09800 + ((_n) * 0x100) }
+pub fn IXGBE_FHFT_EXT(n: u32) -> u32 { 0x09800 + n * 0x100 }
 
-pub fn IXGBE_FHFT_EXT_X550(_n: u32) -> u32 { 0x09600 + ((_n) * 0x100) }
+pub fn IXGBE_FHFT_EXT_X550(n: u32) -> u32 { 0x09600 + n * 0x100 }
 
 /* Four Flexible Filters are supported */
 pub const IXGBE_FLEXIBLE_FILTER_COUNT_MAX: u32                         = 4;
@@ -683,12 +683,12 @@ pub const IXGBE_DPMCS: u32                                             = 0x07F40
 pub const IXGBE_PDPMCS: u32                                            = 0x0CD00;
 pub const IXGBE_RUPPBMR: u32                                           = 0x050A0;
 
-pub fn IXGBE_RT2CR(_i: u32) -> u32 { 0x03C20 + ((_i) * 4) } /* 8 of these (0-7) */
-pub fn IXGBE_RT2SR(_i: u32) -> u32 { 0x03C40 + ((_i) * 4) } /* 8 of these (0-7) */
-pub fn IXGBE_TDTQ2TCCR(_i: u32) -> u32 { 0x0602C + ((_i) * 0x40) } /* 8 of these (0-7) */
-pub fn IXGBE_TDTQ2TCSR(_i: u32) -> u32 { 0x0622C + ((_i) * 0x40) } /* 8 of these (0-7) */
-pub fn IXGBE_TDPT2TCCR(_i: u32) -> u32 { 0x0CD20 + ((_i) * 4) } /* 8 of these (0-7) */
-pub fn IXGBE_TDPT2TCSR(_i: u32) -> u32 { 0x0CD40 + ((_i) * 4) } /* 8 of these (0-7) */
+pub fn IXGBE_RT2CR(i: u32) -> u32 { 0x03C20 + i * 4 } /* 8 of these (0-7) */
+pub fn IXGBE_RT2SR(i: u32) -> u32 { 0x03C40 + i * 4 } /* 8 of these (0-7) */
+pub fn IXGBE_TDTQ2TCCR(i: u32) -> u32 { 0x0602C + i * 0x40 } /* 8 of these (0-7) */
+pub fn IXGBE_TDTQ2TCSR(i: u32) -> u32 { 0x0622C + i * 0x40 } /* 8 of these (0-7) */
+pub fn IXGBE_TDPT2TCCR(i: u32) -> u32 { 0x0CD20 + i * 4 } /* 8 of these (0-7) */
+pub fn IXGBE_TDPT2TCSR(i: u32) -> u32 { 0x0CD40 + i * 4 } /* 8 of these (0-7) */
 
 /* Power Management */
 /* DMA Coalescing configuration */
@@ -714,7 +714,7 @@ pub const IXGBE_DMACRXT_100M: u32                                      = 0x01;
 /* DMA Coalescing registers */
 pub const IXGBE_DMCMNGTH: u32                                          = 0x15F20; /* Management Threshold */
 pub const IXGBE_DMACR: u32                                             = 0x02400; /* Control register */
-pub fn IXGBE_DMCTH(_i: u32) -> u32 { 0x03300 + ((_i) * 4) } /* 8 of these */
+pub fn IXGBE_DMCTH(i: u32) -> u32 { 0x03300 + i * 4 } /* 8 of these */
 pub const IXGBE_DMCTLX: u32                                            = 0x02404; /* Time to Lx request */
 /* DMA Coalescing register fields */
 pub const IXGBE_DMCMNGTH_DMCMNGTH_MASK: u32                            = 0x000FFFF0; /* Mng Threshold mask */
@@ -776,15 +776,15 @@ pub const IXGBE_LSECTXSA: u32                                          = 0x08A10
 pub const IXGBE_LSECTXPN0: u32                                         = 0x08A14;
 pub const IXGBE_LSECTXPN1: u32                                         = 0x08A18;
 
-pub fn IXGBE_LSECTXKEY0(_n: u32) -> u32 { 0x08A1C + (4 * (_n)) } /* 4 of these (0-3) */
-pub fn IXGBE_LSECTXKEY1(_n: u32) -> u32 { 0x08A2C + (4 * (_n)) } /* 4 of these (0-3) */
+pub fn IXGBE_LSECTXKEY0(n: u32) -> u32 { 0x08A1C + 4 * n } /* 4 of these (0-3) */
+pub fn IXGBE_LSECTXKEY1(n: u32) -> u32 { 0x08A2C + 4 * n } /* 4 of these (0-3) */
 pub const IXGBE_LSECRXCTRL: u32                                        = 0x08F04;
 pub const IXGBE_LSECRXSCL: u32                                         = 0x08F08;
 pub const IXGBE_LSECRXSCH: u32                                         = 0x08F0C;
 
-pub fn IXGBE_LSECRXSA(_i: u32) -> u32 { 0x08F10 + (4 * (_i)) } /* 2 of these (0-1) */
-pub fn IXGBE_LSECRXPN(_i: u32) -> u32 { 0x08F18 + (4 * (_i)) } /* 2 of these (0-1) */
-pub fn IXGBE_LSECRXKEY(_n: u32, _m: u32) -> u32 { 0x08F20 + ((0x10 * (_n)) + (4 * _m)) }
+pub fn IXGBE_LSECRXSA(i: u32) -> u32 { 0x08F10 + 4 * i } /* 2 of these (0-1) */
+pub fn IXGBE_LSECRXPN(i: u32) -> u32 { 0x08F18 + 4 * i } /* 2 of these (0-1) */
+pub fn IXGBE_LSECRXKEY(n: u32, m: u32) -> u32 { 0x08F20 + (0x10 * n + 4 * m) }
 
 pub const IXGBE_LSECTXUT: u32                                          = 0x08A3C; /* OutPktsUntagged */
 pub const IXGBE_LSECTXPKTE: u32                                        = 0x08A40; /* OutPktsEncrypted */
@@ -800,9 +800,9 @@ pub const IXGBE_LSECRXUNSCI: u32                                       = 0x08F54
 pub const IXGBE_LSECRXUNCH: u32                                        = 0x08F58; /* InPktsUnchecked */
 pub const IXGBE_LSECRXDELAY: u32                                       = 0x08F5C; /* InPktsDelayed */
 pub const IXGBE_LSECRXLATE: u32                                        = 0x08F60; /* InPktsLate */
-pub fn IXGBE_LSECRXOK(_n: u32) -> u32 { 0x08F64 + (0x04 * (_n)) } /* InPktsOk */
-pub fn IXGBE_LSECRXINV(_n: u32) -> u32 { 0x08F6C + (0x04 * (_n)) } /* InPktsInvalid */
-pub fn IXGBE_LSECRXNV(_n: u32) -> u32 { 0x08F74 + (0x04 * (_n)) } /* InPktsNotValid */
+pub fn IXGBE_LSECRXOK(n: u32) -> u32 { 0x08F64 + 0x04 * n } /* InPktsOk */
+pub fn IXGBE_LSECRXINV(n: u32) -> u32 { 0x08F6C + 0x04 * n } /* InPktsInvalid */
+pub fn IXGBE_LSECRXNV(n: u32) -> u32 { 0x08F74 + 0x04 * n } /* InPktsNotValid */
 pub const IXGBE_LSECRXUNSA: u32                                        = 0x08F7C; /* InPktsUnusedSa */
 pub const IXGBE_LSECRXNUSA: u32                                        = 0x08F80; /* InPktsNotUsingSa */
 
@@ -834,14 +834,14 @@ pub const IXGBE_LSECRXCTRL_RSV_MASK: u32                               = 0xFFFFF
 pub const IXGBE_IPSTXIDX: u32                                          = 0x08900;
 pub const IXGBE_IPSTXSALT: u32                                         = 0x08904;
 
-pub fn IXGBE_IPSTXKEY(_i: u32) -> u32 { 0x08908 + (4 * (_i)) } /* 4 of these (0-3) */
+pub fn IXGBE_IPSTXKEY(i: u32) -> u32 { 0x08908 + 4 * i } /* 4 of these (0-3) */
 pub const IXGBE_IPSRXIDX: u32                                          = 0x08E00;
 
-pub fn IXGBE_IPSRXIPADDR(_i: u32) -> u32 { 0x08E04 + (4 * (_i)) } /* 4 of these (0-3) */
+pub fn IXGBE_IPSRXIPADDR(i: u32) -> u32 { 0x08E04 + 4 * i } /* 4 of these (0-3) */
 pub const IXGBE_IPSRXSPI: u32                                          = 0x08E14;
 pub const IXGBE_IPSRXIPIDX: u32                                        = 0x08E18;
 
-pub fn IXGBE_IPSRXKEY(_i: u32) -> u32 { 0x08E1C + (4 * (_i)) } /* 4 of these (0-3) */
+pub fn IXGBE_IPSRXKEY(i: u32) -> u32 { 0x08E1C + 4 * i } /* 4 of these (0-3) */
 pub const IXGBE_IPSRXSALT: u32                                         = 0x08E2C;
 pub const IXGBE_IPSRXMOD: u32                                          = 0x08E30;
 
@@ -855,13 +855,13 @@ pub const IXGBE_RTTPCS: u32                                            = 0x0CD00
 pub const IXGBE_RTRUP2TC: u32                                          = 0x03020;
 pub const IXGBE_RTTUP2TC: u32                                          = 0x0C800;
 
-pub fn IXGBE_RTRPT4C(_i: u32) -> u32 { 0x02140 + ((_i) * 4) } /* 8 of these (0-7) */
-pub fn IXGBE_TXLLQ(_i: u32) -> u32 { 0x082E0 + ((_i) * 4) } /* 4 of these (0-3) */
-pub fn IXGBE_RTRPT4S(_i: u32) -> u32 { 0x02160 + ((_i) * 4) } /* 8 of these (0-7) */
-pub fn IXGBE_RTTDT2C(_i: u32) -> u32 { 0x04910 + ((_i) * 4) } /* 8 of these (0-7) */
-pub fn IXGBE_RTTDT2S(_i: u32) -> u32 { 0x04930 + ((_i) * 4) } /* 8 of these (0-7) */
-pub fn IXGBE_RTTPT2C(_i: u32) -> u32 { 0x0CD20 + ((_i) * 4) } /* 8 of these (0-7) */
-pub fn IXGBE_RTTPT2S(_i: u32) -> u32 { 0x0CD40 + ((_i) * 4) } /* 8 of these (0-7) */
+pub fn IXGBE_RTRPT4C(i: u32) -> u32 { 0x02140 + i * 4 } /* 8 of these (0-7) */
+pub fn IXGBE_TXLLQ(i: u32) -> u32 { 0x082E0 + i * 4 } /* 4 of these (0-3) */
+pub fn IXGBE_RTRPT4S(i: u32) -> u32 { 0x02160 + i * 4 } /* 8 of these (0-7) */
+pub fn IXGBE_RTTDT2C(i: u32) -> u32 { 0x04910 + i * 4 } /* 8 of these (0-7) */
+pub fn IXGBE_RTTDT2S(i: u32) -> u32 { 0x04930 + i * 4 } /* 8 of these (0-7) */
+pub fn IXGBE_RTTPT2C(i: u32) -> u32 { 0x0CD20 + i * 4 } /* 8 of these (0-7) */
+pub fn IXGBE_RTTPT2S(i: u32) -> u32 { 0x0CD40 + i * 4 } /* 8 of these (0-7) */
 pub const IXGBE_RTTDQSEL: u32                                          = 0x04904;
 pub const IXGBE_RTTDT1C: u32                                           = 0x04908;
 pub const IXGBE_RTTDT1S: u32                                           = 0x0490C;
@@ -890,7 +890,7 @@ pub const IXGBE_RTTBCNRD: u32                                          = 0x0498C
 
 /* FCoE DMA Context Registers */
 /* FCoE Direct DMA Context */
-pub fn IXGBE_FCDDC(_i: u32, _j: u32) -> u32 { 0x20000 + (_i * 0x4) + (_j * 0x10) }
+pub fn IXGBE_FCDDC(i: u32, j: u32) -> u32 { 0x20000 + i * 0x4 + j * 0x10 }
 
 pub const IXGBE_FCPTRL: u32                                            = 0x02410; /* FC User Desc. PTR Low */
 pub const IXGBE_FCPTRH: u32                                            = 0x02414; /* FC USer Desc. PTR High */
@@ -919,9 +919,9 @@ pub const IXGBE_FCD_ID: u32                                            = 0x05114
 pub const IXGBE_FCSMAC: u32                                            = 0x0510C; /* FCoE Source MAC */
 pub const IXGBE_FCFLTRW_SMAC_HIGH_SHIFT: u32                           = 16;
 /* FCoE Direct Filter Context */
-pub fn IXGBE_FCDFC(_i: u32, _j: u32) -> u32 { 0x28000 + ((_i) * 0x4) + ((_j) * 0x10) }
+pub fn IXGBE_FCDFC(i: u32, j: u32) -> u32 { 0x28000 + i * 0x4 + j * 0x10 }
 
-pub fn IXGBE_FCDFCD(_i: u32) -> u32 { 0x30000 + ((_i) * 0x4) }
+pub fn IXGBE_FCDFCD(i: u32) -> u32 { 0x30000 + i * 0x4 }
 
 pub const IXGBE_FCFLT: u32                                             = 0x05108; /* FC FLT Context */
 pub const IXGBE_FCFLTRW: u32                                           = 0x05110; /* FC Filter RW Control */
@@ -948,7 +948,7 @@ pub const IXGBE_FCRXCTRL_FCOEVER_SHIFT: u32                            = 8;
 /* FCoE Redirection */
 pub const IXGBE_FCRECTL: u32                                           = 0x0ED00; /* FC Redirection Control */
 pub const IXGBE_FCRETA0: u32                                           = 0x0ED10; /* FC Redirection Table 0 */
-pub fn IXGBE_FCRETA(_i: u32) -> u32 { IXGBE_FCRETA0 + ((_i) * 4) } /* FCoE Redir */
+pub fn IXGBE_FCRETA(i: u32) -> u32 { IXGBE_FCRETA0 + i * 4 } /* FCoE Redir */
 pub const IXGBE_FCRECTL_ENA: u32                                       = 0x1; /* FCoE Redir Table Enable */
 pub const IXGBE_FCRETASEL_ENA: u32                                     = 0x2; /* FCoE FCRETASEL bit */
 pub const IXGBE_FCRETA_SIZE: u32                                       = 8; /* Max entries in FCRETA */
@@ -964,7 +964,7 @@ pub const IXGBE_ILLERRC: u32                                           = 0x04004
 pub const IXGBE_ERRBC: u32                                             = 0x04008;
 pub const IXGBE_MSPDC: u32                                             = 0x04010;
 
-pub fn IXGBE_MPC(_i: u32) -> u32 { 0x03FA0 + ((_i) * 4) } /* 8 of these 3FA0-3FBC*/
+pub fn IXGBE_MPC(i: u32) -> u32 { 0x03FA0 + i * 4 } /* 8 of these 3FA0-3FBC*/
 pub const IXGBE_MLFC: u32                                              = 0x04034;
 pub const IXGBE_MRFC: u32                                              = 0x04038;
 pub const IXGBE_RLEC: u32                                              = 0x04040;
@@ -975,13 +975,13 @@ pub const IXGBE_LXOFFRXC: u32                                          = 0x0CF68
 pub const IXGBE_LXONRXCNT: u32                                         = 0x041A4;
 pub const IXGBE_LXOFFRXCNT: u32                                        = 0x041A8;
 
-pub fn IXGBE_PXONRXCNT(_i: u32) -> u32 { 0x04140 + ((_i) * 4) } /* 8 of these */
-pub fn IXGBE_PXOFFRXCNT(_i: u32) -> u32 { 0x04160 + ((_i) * 4) } /* 8 of these */
-pub fn IXGBE_PXON2OFFCNT(_i: u32) -> u32 { 0x03240 + ((_i) * 4) } /* 8 of these */
-pub fn IXGBE_PXONTXC(_i: u32) -> u32 { 0x03F00 + ((_i) * 4) } /* 8 of these 3F00-3F1C*/
-pub fn IXGBE_PXONRXC(_i: u32) -> u32 { 0x0CF00 + ((_i) * 4) } /* 8 of these CF00-CF1C*/
-pub fn IXGBE_PXOFFTXC(_i: u32) -> u32 { 0x03F20 + ((_i) * 4) } /* 8 of these 3F20-3F3C*/
-pub fn IXGBE_PXOFFRXC(_i: u32) -> u32 { 0x0CF20 + ((_i) * 4) } /* 8 of these CF20-CF3C*/
+pub fn IXGBE_PXONRXCNT(i: u32) -> u32 { 0x04140 + i * 4 } /* 8 of these */
+pub fn IXGBE_PXOFFRXCNT(i: u32) -> u32 { 0x04160 + i * 4 } /* 8 of these */
+pub fn IXGBE_PXON2OFFCNT(i: u32) -> u32 { 0x03240 + i * 4 } /* 8 of these */
+pub fn IXGBE_PXONTXC(i: u32) -> u32 { 0x03F00 + i * 4 } /* 8 of these 3F00-3F1C*/
+pub fn IXGBE_PXONRXC(i: u32) -> u32 { 0x0CF00 + i * 4 } /* 8 of these CF00-CF1C*/
+pub fn IXGBE_PXOFFTXC(i: u32) -> u32 { 0x03F20 + i * 4 } /* 8 of these 3F20-3F3C*/
+pub fn IXGBE_PXOFFRXC(i: u32) -> u32 { 0x0CF20 + i * 4 } /* 8 of these CF20-CF3C*/
 pub const IXGBE_PRC64: u32                                             = 0x0405C;
 pub const IXGBE_PRC127: u32                                            = 0x04060;
 pub const IXGBE_PRC255: u32                                            = 0x04064;
@@ -997,7 +997,7 @@ pub const IXGBE_GORCH: u32                                             = 0x0408C
 pub const IXGBE_GOTCL: u32                                             = 0x04090;
 pub const IXGBE_GOTCH: u32                                             = 0x04094;
 
-pub fn IXGBE_RNBC(_i: u32) -> u32 { 0x03FC0 + ((_i) * 4) } /* 8 of these 3FC0-3FDC*/
+pub fn IXGBE_RNBC(i: u32) -> u32 { 0x03FC0 + i * 4 } /* 8 of these 3FC0-3FDC*/
 pub const IXGBE_RUC: u32                                               = 0x040A4;
 pub const IXGBE_RFC: u32                                               = 0x040A8;
 pub const IXGBE_ROC: u32                                               = 0x040AC;
@@ -1020,21 +1020,21 @@ pub const IXGBE_BPTC: u32                                              = 0x040F4
 pub const IXGBE_XEC: u32                                               = 0x04120;
 pub const IXGBE_SSVPC: u32                                             = 0x08780;
 
-pub fn IXGBE_RQSMR(_i: u32) -> u32 { 0x02300 + ((_i) * 4) }
+pub fn IXGBE_RQSMR(i: u32) -> u32 { 0x02300 + i * 4 }
 
-pub fn IXGBE_TQSMR(_i: u32) -> u32 { if _i <= 7 { 0x07300 + (_i * 4) } else { 0x08600 + (_i * 4) } }
+pub fn IXGBE_TQSMR(i: u32) -> u32 { if i <= 7 { 0x07300 + i * 4 } else { 0x08600 + i * 4 } }
 
-pub fn IXGBE_TQSM(_i: u32) -> u32 { 0x08600 + ((_i) * 4) }
+pub fn IXGBE_TQSM(i: u32) -> u32 { 0x08600 + i * 4 }
 
-pub fn IXGBE_QPRC(_i: u32) -> u32 { 0x01030 + ((_i) * 0x40) } /* 16 of these */
-pub fn IXGBE_QPTC(_i: u32) -> u32 { 0x06030 + ((_i) * 0x40) } /* 16 of these */
-pub fn IXGBE_QBRC(_i: u32) -> u32 { 0x01034 + ((_i) * 0x40) } /* 16 of these */
-pub fn IXGBE_QBTC(_i: u32) -> u32 { 0x06034 + ((_i) * 0x40) } /* 16 of these */
-pub fn IXGBE_QBRC_L(_i: u32) -> u32 { 0x01034 + ((_i) * 0x40) } /* 16 of these */
-pub fn IXGBE_QBRC_H(_i: u32) -> u32 { 0x01038 + ((_i) * 0x40) } /* 16 of these */
-pub fn IXGBE_QPRDC(_i: u32) -> u32 { 0x01430 + ((_i) * 0x40) } /* 16 of these */
-pub fn IXGBE_QBTC_L(_i: u32) -> u32 { 0x08700 + ((_i) * 0x8) } /* 16 of these */
-pub fn IXGBE_QBTC_H(_i: u32) -> u32 { 0x08704 + ((_i) * 0x8) } /* 16 of these */
+pub fn IXGBE_QPRC(i: u32) -> u32 { 0x01030 + i * 0x40 } /* 16 of these */
+pub fn IXGBE_QPTC(i: u32) -> u32 { 0x06030 + i * 0x40 } /* 16 of these */
+pub fn IXGBE_QBRC(i: u32) -> u32 { 0x01034 + i * 0x40 } /* 16 of these */
+pub fn IXGBE_QBTC(i: u32) -> u32 { 0x06034 + i * 0x40 } /* 16 of these */
+pub fn IXGBE_QBRC_L(i: u32) -> u32 { 0x01034 + i * 0x40 } /* 16 of these */
+pub fn IXGBE_QBRC_H(i: u32) -> u32 { 0x01038 + i * 0x40 } /* 16 of these */
+pub fn IXGBE_QPRDC(i: u32) -> u32 { 0x01430 + i * 0x40 } /* 16 of these */
+pub fn IXGBE_QBTC_L(i: u32) -> u32 { 0x08700 + i * 0x8 } /* 16 of these */
+pub fn IXGBE_QBTC_H(i: u32) -> u32 { 0x08704 + i * 0x8 } /* 16 of these */
 pub const IXGBE_FCCRC: u32                                             = 0x05118; /* Num of Good Eth CRC w/ Bad FC CRC */
 pub const IXGBE_FCOERPDC: u32                                          = 0x0241C; /* FCoE Rx Packets Dropped Count */
 pub const IXGBE_FCLAST: u32                                            = 0x02424; /* FCoE Last Error Count */
@@ -1061,23 +1061,23 @@ pub const IXGBE_BXONTXC: u32                                           = 0x041E4
 pub const IXGBE_BXOFFTXC: u32                                          = 0x041E8;
 
 /* Management */
-pub fn IXGBE_MAVTV(_i: u32) -> u32 { 0x05010 + ((_i) * 4) } /* 8 of these (0-7) */
-pub fn IXGBE_MFUTP(_i: u32) -> u32 { 0x05030 + ((_i) * 4) } /* 8 of these (0-7) */
+pub fn IXGBE_MAVTV(i: u32) -> u32 { 0x05010 + i * 4 } /* 8 of these (0-7) */
+pub fn IXGBE_MFUTP(i: u32) -> u32 { 0x05030 + i * 4 } /* 8 of these (0-7) */
 pub const IXGBE_MANC: u32                                              = 0x05820;
 pub const IXGBE_MFVAL: u32                                             = 0x05824;
 pub const IXGBE_MANC2H: u32                                            = 0x05860;
 
-pub fn IXGBE_MDEF(_i: u32) -> u32 { 0x05890 + ((_i) * 4) } /* 8 of these (0-7) */
+pub fn IXGBE_MDEF(i: u32) -> u32 { 0x05890 + i * 4 } /* 8 of these (0-7) */
 pub const IXGBE_MIPAF: u32                                             = 0x058B0;
 
-pub fn IXGBE_MMAL(_i: u32) -> u32 { 0x05910 + ((_i) * 8) } /* 4 of these (0-3) */
-pub fn IXGBE_MMAH(_i: u32) -> u32 { 0x05914 + ((_i) * 8) } /* 4 of these (0-3) */
+pub fn IXGBE_MMAL(i: u32) -> u32 { 0x05910 + i * 8 } /* 4 of these (0-3) */
+pub fn IXGBE_MMAH(i: u32) -> u32 { 0x05914 + i * 8 } /* 4 of these (0-3) */
 pub const IXGBE_FTFT: u32                                              = 0x09400; /* 0x9400-0x97FC */
-pub fn IXGBE_METF(_i: u32) -> u32 { 0x05190 + ((_i) * 4) } /* 4 of these (0-3) */
-pub fn IXGBE_MDEF_EXT(_i: u32) -> u32 { 0x05160 + ((_i) * 4) } /* 8 of these (0-7) */
+pub fn IXGBE_METF(i: u32) -> u32 { 0x05190 + i * 4 } /* 4 of these (0-3) */
+pub fn IXGBE_MDEF_EXT(i: u32) -> u32 { 0x05160 + i * 4 } /* 8 of these (0-7) */
 pub const IXGBE_LSWFW: u32                                             = 0x15F14;
 
-pub fn IXGBE_BMCIP(_i: u32) -> u32 { 0x05050 + ((_i) * 4) } /* 0x5050-0x505C */
+pub fn IXGBE_BMCIP(i: u32) -> u32 { 0x05050 + i * 4 } /* 0x5050-0x505C */
 pub const IXGBE_BMCIPVAL: u32                                          = 0x05060;
 pub const IXGBE_BMCIP_IPADDR_TYPE: u32                                 = 0x00000001;
 pub const IXGBE_BMCIP_IPADDR_VALID: u32                                = 0x00000002;
@@ -1154,7 +1154,7 @@ pub const IXGBE_GSCN_2_X550EM_a: u32                                   = IXGBE_G
 pub const IXGBE_GSCN_3_X550EM_a: u32                                   = IXGBE_GSCN_3_X550;
 pub const IXGBE_FACTPS_X550EM_a: u32                                   = 0x15FEC;
 
-pub fn IXGBE_FACTPS_BY_MAC(_hw: u32) -> u32 { IXGBE_BY_MAC(_hw, IXGBE_FACTPS) }
+pub fn IXGBE_FACTPS_BY_MAC(hw: u32) -> u32 { IXGBE_BY_MAC(hw, IXGBE_FACTPS) }
 
 pub const IXGBE_PCIEANACTL: u32                                        = 0x11040;
 pub const IXGBE_SWSM: u32                                              = 0x10140;
@@ -1163,7 +1163,7 @@ pub const IXGBE_SWSM_X550: u32                                         = IXGBE_S
 pub const IXGBE_SWSM_X550EM_x: u32                                     = IXGBE_SWSM;
 pub const IXGBE_SWSM_X550EM_a: u32                                     = 0x15F70;
 
-pub fn IXGBE_SWSM_BY_MAC(_hw: u32) -> u32 { IXGBE_BY_MAC(_hw, IXGBE_SWSM) }
+pub fn IXGBE_SWSM_BY_MAC(hw: u32) -> u32 { IXGBE_BY_MAC(hw, IXGBE_SWSM) }
 
 pub const IXGBE_FWSM: u32                                              = 0x10148;
 pub const IXGBE_FWSM_X540: u32                                         = IXGBE_FWSM;
@@ -1171,7 +1171,7 @@ pub const IXGBE_FWSM_X550: u32                                         = IXGBE_F
 pub const IXGBE_FWSM_X550EM_x: u32                                     = IXGBE_FWSM;
 pub const IXGBE_FWSM_X550EM_a: u32                                     = 0x15F74;
 
-pub fn IXGBE_FWSM_BY_MAC(_hw: u32) -> u32 { IXGBE_BY_MAC(_hw, IXGBE_FWSM) }
+pub fn IXGBE_FWSM_BY_MAC(hw: u32) -> u32 { IXGBE_BY_MAC(hw, IXGBE_FWSM) }
 
 pub const IXGBE_SWFW_SYNC: u32                                         = IXGBE_GSSR;
 pub const IXGBE_SWFW_SYNC_X540: u32                                    = IXGBE_SWFW_SYNC;
@@ -1179,7 +1179,7 @@ pub const IXGBE_SWFW_SYNC_X550: u32                                    = IXGBE_S
 pub const IXGBE_SWFW_SYNC_X550EM_x: u32                                = IXGBE_SWFW_SYNC;
 pub const IXGBE_SWFW_SYNC_X550EM_a: u32                                = 0x15F78;
 
-pub fn IXGBE_SWFW_SYNC_BY_MAC(_hw: u32) -> u32 { IXGBE_BY_MAC(_hw, IXGBE_SWFW_SYNC) }
+pub fn IXGBE_SWFW_SYNC_BY_MAC(hw: u32) -> u32 { IXGBE_BY_MAC(hw, IXGBE_SWFW_SYNC) }
 
 pub const IXGBE_GSSR: u32                                              = 0x10160;
 pub const IXGBE_MREVID: u32                                            = 0x11064;
@@ -1225,9 +1225,9 @@ pub const IXGBE_GSCL_8_X550EM_a: u32                                   = IXGBE_G
 pub const IXGBE_CIAA_X550EM_a: u32                                     = IXGBE_CIAA_X550;
 pub const IXGBE_CIAD_X550EM_a: u32                                     = IXGBE_CIAD_X550;
 
-pub fn IXGBE_CIAA_BY_MAC(_hw: u32) -> u32 { IXGBE_BY_MAC(_hw, IXGBE_CIAA) }
+pub fn IXGBE_CIAA_BY_MAC(hw: u32) -> u32 { IXGBE_BY_MAC(hw, IXGBE_CIAA) }
 
-pub fn IXGBE_CIAD_BY_MAC(_hw: u32) -> u32 { IXGBE_BY_MAC(_hw, IXGBE_CIAD) }
+pub fn IXGBE_CIAD_BY_MAC(hw: u32) -> u32 { IXGBE_BY_MAC(hw, IXGBE_CIAD) }
 
 pub const IXGBE_PICAUSE: u32                                           = 0x110B0;
 pub const IXGBE_PIENA: u32                                             = 0x110B8;
@@ -1288,10 +1288,10 @@ pub const IXGBE_TSSDP: u32                                             = 0x0003C
 /* Diagnostic Registers */
 pub const IXGBE_RDSTATCTL: u32                                         = 0x02C20;
 
-pub fn IXGBE_RDSTAT(_i: u32) -> u32 { 0x02C00 + ((_i) * 4) } /* 0x02C00-0x02C1C */
+pub fn IXGBE_RDSTAT(i: u32) -> u32 { 0x02C00 + i * 4 } /* 0x02C00-0x02C1C */
 pub const IXGBE_RDHMPN: u32                                            = 0x02F08;
 
-pub fn IXGBE_RIC_DW(_i: u32) -> u32 { 0x02F10 + ((_i) * 4) }
+pub fn IXGBE_RIC_DW(i: u32) -> u32 { 0x02F10 + i * 4 }
 
 pub const IXGBE_RDPROBE: u32                                           = 0x02F20;
 pub const IXGBE_RDMAM: u32                                             = 0x02F30;
@@ -1300,9 +1300,9 @@ pub const IXGBE_TDHMPN: u32                                            = 0x07F08
 pub const IXGBE_TDHMPN2: u32                                           = 0x082FC;
 pub const IXGBE_TXDESCIC: u32                                          = 0x082CC;
 
-pub fn IXGBE_TIC_DW(_i: u32) -> u32 { 0x07F10 + ((_i) * 4) }
+pub fn IXGBE_TIC_DW(i: u32) -> u32 { 0x07F10 + i * 4 }
 
-pub fn IXGBE_TIC_DW2(_i: u32) -> u32 { 0x082B0 + ((_i) * 4) }
+pub fn IXGBE_TIC_DW2(i: u32) -> u32 { 0x082B0 + i * 4 }
 
 pub const IXGBE_TDPROBE: u32                                           = 0x07F20;
 pub const IXGBE_TXBUFCTRL: u32                                         = 0x0C600;
@@ -1316,7 +1316,7 @@ pub const IXGBE_RXBUFDATA1: u32                                        = 0x03614
 pub const IXGBE_RXBUFDATA2: u32                                        = 0x03618;
 pub const IXGBE_RXBUFDATA3: u32                                        = 0x0361C;
 
-pub fn IXGBE_PCIE_DIAG(_i: u32) -> u32 { 0x11090 + ((_i) * 4) } /* 8 of these */
+pub fn IXGBE_PCIE_DIAG(i: u32) -> u32 { 0x11090 + i * 4 } /* 8 of these */
 pub const IXGBE_RFVAL: u32                                             = 0x050A4;
 pub const IXGBE_MDFTC1: u32                                            = 0x042B8;
 pub const IXGBE_MDFTC2: u32                                            = 0x042C0;
@@ -1324,24 +1324,24 @@ pub const IXGBE_MDFTFIFO1: u32                                         = 0x042C4
 pub const IXGBE_MDFTFIFO2: u32                                         = 0x042C8;
 pub const IXGBE_MDFTS: u32                                             = 0x042CC;
 
-pub fn IXGBE_RXDATAWRPTR(_i: u32) -> u32 { 0x03700 + ((_i) * 4) } /* 8 of these 3700-370C */
-pub fn IXGBE_RXDESCWRPTR(_i: u32) -> u32 { 0x03710 + ((_i) * 4) } /* 8 of these 3710-371C */
-pub fn IXGBE_RXDATARDPTR(_i: u32) -> u32 { 0x03720 + ((_i) * 4) } /* 8 of these 3720-372C */
-pub fn IXGBE_RXDESCRDPTR(_i: u32) -> u32 { 0x03730 + ((_i) * 4) } /* 8 of these 3730-373C */
-pub fn IXGBE_TXDATAWRPTR(_i: u32) -> u32 { 0x0C700 + ((_i) * 4) } /* 8 of these C700-C70C */
-pub fn IXGBE_TXDESCWRPTR(_i: u32) -> u32 { 0x0C710 + ((_i) * 4) } /* 8 of these C710-C71C */
-pub fn IXGBE_TXDATARDPTR(_i: u32) -> u32 { 0x0C720 + ((_i) * 4) } /* 8 of these C720-C72C */
-pub fn IXGBE_TXDESCRDPTR(_i: u32) -> u32 { 0x0C730 + ((_i) * 4) } /* 8 of these C730-C73C */
+pub fn IXGBE_RXDATAWRPTR(i: u32) -> u32 { 0x03700 + i * 4 } /* 8 of these 3700-370C */
+pub fn IXGBE_RXDESCWRPTR(i: u32) -> u32 { 0x03710 + i * 4 } /* 8 of these 3710-371C */
+pub fn IXGBE_RXDATARDPTR(i: u32) -> u32 { 0x03720 + i * 4 } /* 8 of these 3720-372C */
+pub fn IXGBE_RXDESCRDPTR(i: u32) -> u32 { 0x03730 + i * 4 } /* 8 of these 3730-373C */
+pub fn IXGBE_TXDATAWRPTR(i: u32) -> u32 { 0x0C700 + i * 4 } /* 8 of these C700-C70C */
+pub fn IXGBE_TXDESCWRPTR(i: u32) -> u32 { 0x0C710 + i * 4 } /* 8 of these C710-C71C */
+pub fn IXGBE_TXDATARDPTR(i: u32) -> u32 { 0x0C720 + i * 4 } /* 8 of these C720-C72C */
+pub fn IXGBE_TXDESCRDPTR(i: u32) -> u32 { 0x0C730 + i * 4 } /* 8 of these C730-C73C */
 pub const IXGBE_PCIEECCCTL: u32                                        = 0x1106C;
 
-pub fn IXGBE_RXWRPTR(_i: u32) -> u32 { 0x03100 + ((_i) * 4) } /* 8 of these 3100-310C */
-pub fn IXGBE_RXUSED(_i: u32) -> u32 { 0x03120 + ((_i) * 4) } /* 8 of these 3120-312C */
-pub fn IXGBE_RXRDPTR(_i: u32) -> u32 { 0x03140 + ((_i) * 4) } /* 8 of these 3140-314C */
-pub fn IXGBE_RXRDWRPTR(_i: u32) -> u32 { 0x03160 + ((_i) * 4) } /* 8 of these 3160-310C */
-pub fn IXGBE_TXWRPTR(_i: u32) -> u32 { 0x0C100 + ((_i) * 4) } /* 8 of these C100-C10C */
-pub fn IXGBE_TXUSED(_i: u32) -> u32 { 0x0C120 + ((_i) * 4) } /* 8 of these C120-C12C */
-pub fn IXGBE_TXRDPTR(_i: u32) -> u32 { 0x0C140 + ((_i) * 4) } /* 8 of these C140-C14C */
-pub fn IXGBE_TXRDWRPTR(_i: u32) -> u32 { 0x0C160 + ((_i) * 4) } /* 8 of these C160-C10C */
+pub fn IXGBE_RXWRPTR(i: u32) -> u32 { 0x03100 + i * 4 } /* 8 of these 3100-310C */
+pub fn IXGBE_RXUSED(i: u32) -> u32 { 0x03120 + i * 4 } /* 8 of these 3120-312C */
+pub fn IXGBE_RXRDPTR(i: u32) -> u32 { 0x03140 + i * 4 } /* 8 of these 3140-314C */
+pub fn IXGBE_RXRDWRPTR(i: u32) -> u32 { 0x03160 + i * 4 } /* 8 of these 3160-310C */
+pub fn IXGBE_TXWRPTR(i: u32) -> u32 { 0x0C100 + i * 4 } /* 8 of these C100-C10C */
+pub fn IXGBE_TXUSED(i: u32) -> u32 { 0x0C120 + i * 4 } /* 8 of these C120-C12C */
+pub fn IXGBE_TXRDPTR(i: u32) -> u32 { 0x0C140 + i * 4 } /* 8 of these C140-C14C */
+pub fn IXGBE_TXRDWRPTR(i: u32) -> u32 { 0x0C160 + i * 4 } /* 8 of these C160-C10C */
 pub const IXGBE_PCIEECCCTL0: u32                                       = 0x11100;
 pub const IXGBE_PCIEECCCTL1: u32                                       = 0x11104;
 pub const IXGBE_RXDBUECC: u32                                          = 0x03F70;
@@ -1464,7 +1464,7 @@ pub const IXGBE_RDRXCTL_MBINTEN: u32                                   = 0x10000
 pub const IXGBE_RDRXCTL_MDP_EN: u32                                    = 0x20000000;
 
 /* RQTC Bit Masks and Shifts */
-pub fn IXGBE_RQTC_SHIFT_TC(_i: u32) -> u32 { (_i) * 4 }
+pub fn IXGBE_RQTC_SHIFT_TC(i: u32) -> u32 { i * 4 }
 
 pub const IXGBE_RQTC_TC0_MASK: u32                                     = 0x7 << 0;
 pub const IXGBE_RQTC_TC1_MASK: u32                                     = 0x7 << 4;
@@ -1735,11 +1735,11 @@ pub const IXGBE_SDP0_GPIEN_X550EM_a: u32                               = IXGBE_S
 pub const IXGBE_SDP1_GPIEN_X550EM_a: u32                               = IXGBE_SDP1_GPIEN_X540;
 pub const IXGBE_SDP2_GPIEN_X550EM_a: u32                               = IXGBE_SDP2_GPIEN_X540;
 
-pub fn IXGBE_SDP0_GPIEN_BY_MAC(_hw: u32) -> u32 { IXGBE_BY_MAC(_hw, IXGBE_SDP0_GPIEN) }
+pub fn IXGBE_SDP0_GPIEN_BY_MAC(hw: u32) -> u32 { IXGBE_BY_MAC(hw, IXGBE_SDP0_GPIEN) }
 
-pub fn IXGBE_SDP1_GPIEN_BY_MAC(_hw: u32) -> u32 { IXGBE_BY_MAC(_hw, IXGBE_SDP1_GPIEN) }
+pub fn IXGBE_SDP1_GPIEN_BY_MAC(hw: u32) -> u32 { IXGBE_BY_MAC(hw, IXGBE_SDP1_GPIEN) }
 
-pub fn IXGBE_SDP2_GPIEN_BY_MAC(_hw: u32) -> u32 { IXGBE_BY_MAC(_hw, IXGBE_SDP2_GPIEN) }
+pub fn IXGBE_SDP2_GPIEN_BY_MAC(hw: u32) -> u32 { IXGBE_BY_MAC(hw, IXGBE_SDP2_GPIEN) }
 
 pub const IXGBE_GPIE_MSIX_MODE: u32                                    = 0x00000010; /* MSI-X mode */
 pub const IXGBE_GPIE_OCD: u32                                          = 0x00000020; /* Other Clear Disable */
@@ -1930,11 +1930,11 @@ pub const IXGBE_EICR_GPI_SDP0_X550EM_a: u32                            = IXGBE_E
 pub const IXGBE_EICR_GPI_SDP1_X550EM_a: u32                            = IXGBE_EICR_GPI_SDP1_X540;
 pub const IXGBE_EICR_GPI_SDP2_X550EM_a: u32                            = IXGBE_EICR_GPI_SDP2_X540;
 
-pub fn IXGBE_EICR_GPI_SDP0_BY_MAC(_hw: u32) -> u32 { IXGBE_BY_MAC(_hw, IXGBE_EICR_GPI_SDP0) }
+pub fn IXGBE_EICR_GPI_SDP0_BY_MAC(hw: u32) -> u32 { IXGBE_BY_MAC(hw, IXGBE_EICR_GPI_SDP0) }
 
-pub fn IXGBE_EICR_GPI_SDP1_BY_MAC(_hw: u32) -> u32 { IXGBE_BY_MAC(_hw, IXGBE_EICR_GPI_SDP1) }
+pub fn IXGBE_EICR_GPI_SDP1_BY_MAC(hw: u32) -> u32 { IXGBE_BY_MAC(hw, IXGBE_EICR_GPI_SDP1) }
 
-pub fn IXGBE_EICR_GPI_SDP2_BY_MAC(_hw: u32) -> u32 { IXGBE_BY_MAC(_hw, IXGBE_EICR_GPI_SDP2) }
+pub fn IXGBE_EICR_GPI_SDP2_BY_MAC(hw: u32) -> u32 { IXGBE_BY_MAC(hw, IXGBE_EICR_GPI_SDP2) }
 
 pub const IXGBE_EICR_PBUR: u32                                         = 0x10000000; /* Packet Buffer Handler Error */
 pub const IXGBE_EICR_DHER: u32                                         = 0x20000000; /* Descriptor Handler Error */
@@ -1954,11 +1954,11 @@ pub const IXGBE_EICS_GPI_SDP0: u32                                     = IXGBE_E
 pub const IXGBE_EICS_GPI_SDP1: u32                                     = IXGBE_EICR_GPI_SDP1; /* SDP1 Gen Purpose Int */
 pub const IXGBE_EICS_GPI_SDP2: u32                                     = IXGBE_EICR_GPI_SDP2; /* SDP2 Gen Purpose Int */
 pub const IXGBE_EICS_ECC: u32                                          = IXGBE_EICR_ECC; /* ECC Error */
-pub fn IXGBE_EICS_GPI_SDP0_BY_MAC(_hw: u32) -> u32 { IXGBE_EICR_GPI_SDP0_BY_MAC(_hw) }
+pub fn IXGBE_EICS_GPI_SDP0_BY_MAC(hw: u32) -> u32 { IXGBE_EICR_GPI_SDP0_BY_MAC(hw) }
 
-pub fn IXGBE_EICS_GPI_SDP1_BY_MAC(_hw: u32) -> u32 { IXGBE_EICR_GPI_SDP1_BY_MAC(_hw) }
+pub fn IXGBE_EICS_GPI_SDP1_BY_MAC(hw: u32) -> u32 { IXGBE_EICR_GPI_SDP1_BY_MAC(hw) }
 
-pub fn IXGBE_EICS_GPI_SDP2_BY_MAC(_hw: u32) -> u32 { IXGBE_EICR_GPI_SDP2_BY_MAC(_hw) }
+pub fn IXGBE_EICS_GPI_SDP2_BY_MAC(hw: u32) -> u32 { IXGBE_EICR_GPI_SDP2_BY_MAC(hw) }
 
 pub const IXGBE_EICS_PBUR: u32                                         = IXGBE_EICR_PBUR; /* Pkt Buf Handler Err */
 pub const IXGBE_EICS_DHER: u32                                         = IXGBE_EICR_DHER; /* Desc Handler Error */
@@ -1979,11 +1979,11 @@ pub const IXGBE_EIMS_GPI_SDP0: u32                                     = IXGBE_E
 pub const IXGBE_EIMS_GPI_SDP1: u32                                     = IXGBE_EICR_GPI_SDP1; /* SDP1 Gen Purpose Int */
 pub const IXGBE_EIMS_GPI_SDP2: u32                                     = IXGBE_EICR_GPI_SDP2; /* SDP2 Gen Purpose Int */
 pub const IXGBE_EIMS_ECC: u32                                          = IXGBE_EICR_ECC; /* ECC Error */
-pub fn IXGBE_EIMS_GPI_SDP0_BY_MAC(_hw: u32) -> u32 { IXGBE_EICR_GPI_SDP0_BY_MAC(_hw) }
+pub fn IXGBE_EIMS_GPI_SDP0_BY_MAC(hw: u32) -> u32 { IXGBE_EICR_GPI_SDP0_BY_MAC(hw) }
 
-pub fn IXGBE_EIMS_GPI_SDP1_BY_MAC(_hw: u32) -> u32 { IXGBE_EICR_GPI_SDP1_BY_MAC(_hw) }
+pub fn IXGBE_EIMS_GPI_SDP1_BY_MAC(hw: u32) -> u32 { IXGBE_EICR_GPI_SDP1_BY_MAC(hw) }
 
-pub fn IXGBE_EIMS_GPI_SDP2_BY_MAC(_hw: u32) -> u32 { IXGBE_EICR_GPI_SDP2_BY_MAC(_hw) }
+pub fn IXGBE_EIMS_GPI_SDP2_BY_MAC(hw: u32) -> u32 { IXGBE_EICR_GPI_SDP2_BY_MAC(hw) }
 
 pub const IXGBE_EIMS_PBUR: u32                                         = IXGBE_EICR_PBUR; /* Pkt Buf Handler Err */
 pub const IXGBE_EIMS_DHER: u32                                         = IXGBE_EICR_DHER; /* Descr Handler Error */
@@ -2003,11 +2003,11 @@ pub const IXGBE_EIMC_GPI_SDP0: u32                                     = IXGBE_E
 pub const IXGBE_EIMC_GPI_SDP1: u32                                     = IXGBE_EICR_GPI_SDP1; /* SDP1 Gen Purpose Int */
 pub const IXGBE_EIMC_GPI_SDP2: u32                                     = IXGBE_EICR_GPI_SDP2;  /* SDP2 Gen Purpose Int */
 pub const IXGBE_EIMC_ECC: u32                                          = IXGBE_EICR_ECC; /* ECC Error */
-pub fn IXGBE_EIMC_GPI_SDP0_BY_MAC(_hw: u32) -> u32 { IXGBE_EICR_GPI_SDP0_BY_MAC(_hw) }
+pub fn IXGBE_EIMC_GPI_SDP0_BY_MAC(hw: u32) -> u32 { IXGBE_EICR_GPI_SDP0_BY_MAC(hw) }
 
-pub fn IXGBE_EIMC_GPI_SDP1_BY_MAC(_hw: u32) -> u32 { IXGBE_EICR_GPI_SDP1_BY_MAC(_hw) }
+pub fn IXGBE_EIMC_GPI_SDP1_BY_MAC(hw: u32) -> u32 { IXGBE_EICR_GPI_SDP1_BY_MAC(hw) }
 
-pub fn IXGBE_EIMC_GPI_SDP2_BY_MAC(_hw: u32) -> u32 { IXGBE_EICR_GPI_SDP2_BY_MAC(_hw) }
+pub fn IXGBE_EIMC_GPI_SDP2_BY_MAC(hw: u32) -> u32 { IXGBE_EICR_GPI_SDP2_BY_MAC(hw) }
 
 pub const IXGBE_EIMC_PBUR: u32                                         = IXGBE_EICR_PBUR; /* Pkt Buf Handler Err */
 pub const IXGBE_EIMC_DHER: u32                                         = IXGBE_EICR_DHER; /* Desc Handler Err */
@@ -2069,16 +2069,16 @@ pub const IXGBE_IVAR_REG_NUM_82599: u32                                = 64;
 pub const IXGBE_IVAR_TXRX_ENTRY: u32                                   = 96;
 pub const IXGBE_IVAR_RX_ENTRY: u32                                     = 64;
 
-pub fn IXGBE_IVAR_RX_QUEUE(_i: u32) -> u32 { 0 + (_i) }
+pub fn IXGBE_IVAR_RX_QUEUE(i: u32) -> u32 { 0 + i }
 
-pub fn IXGBE_IVAR_TX_QUEUE(_i: u32) -> u32 { 64 + (_i) }
+pub fn IXGBE_IVAR_TX_QUEUE(i: u32) -> u32 { 64 + i }
 
 pub const IXGBE_IVAR_TX_ENTRY: u32                                     = 32;
 
 pub const IXGBE_IVAR_TCP_TIMER_INDEX: u32                              = 96; /* 0 based index */
 pub const IXGBE_IVAR_OTHER_CAUSES_INDEX: u32                           = 97; /* 0 based index */
 
-pub fn IXGBE_MSIX_VECTOR(_i: u32) -> u32 { 0 + (_i) }
+pub fn IXGBE_MSIX_VECTOR(i: u32) -> u32 { 0 + i }
 
 pub const IXGBE_IVAR_ALLOC_VAL: u32                                    = 0x80; /* Interrupt Allocation valid */
 
@@ -2169,15 +2169,15 @@ pub const IXGBE_LED_IVRT_BASE: u32                                     = 0x00000
 pub const IXGBE_LED_BLINK_BASE: u32                                    = 0x00000080;
 pub const IXGBE_LED_MODE_MASK_BASE: u32                                = 0x0000000F;
 
-pub fn IXGBE_LED_OFFSET(_base: u32, _i: u32) -> u32 { _base << (8 * _i) }
+pub fn IXGBE_LED_OFFSET(base: u32, i: u32) -> u32 { base << (8 * i) }
 
-pub fn IXGBE_LED_MODE_SHIFT(_i: u32) -> u32 { 8 * (_i) }
+pub fn IXGBE_LED_MODE_SHIFT(i: u32) -> u32 { 8 * i }
 
-pub fn IXGBE_LED_IVRT(_i: u32) -> u32 { IXGBE_LED_OFFSET(IXGBE_LED_IVRT_BASE, _i) }
+pub fn IXGBE_LED_IVRT(i: u32) -> u32 { IXGBE_LED_OFFSET(IXGBE_LED_IVRT_BASE, i) }
 
-pub fn IXGBE_LED_BLINK(_i: u32) -> u32 { IXGBE_LED_OFFSET(IXGBE_LED_BLINK_BASE, _i) }
+pub fn IXGBE_LED_BLINK(i: u32) -> u32 { IXGBE_LED_OFFSET(IXGBE_LED_BLINK_BASE, i) }
 
-pub fn IXGBE_LED_MODE_MASK(_i: u32) -> u32 { IXGBE_LED_OFFSET(IXGBE_LED_MODE_MASK_BASE, _i) }
+pub fn IXGBE_LED_MODE_MASK(i: u32) -> u32 { IXGBE_LED_OFFSET(IXGBE_LED_MODE_MASK_BASE, i) }
 
 pub const IXGBE_X557_LED_MANUAL_SET_MASK: u32                          = 1 << 8;
 pub const IXGBE_X557_MAX_LED_INDEX: u32                                = 3;
@@ -2893,94 +2893,94 @@ pub const IXGBE_TX_DESC_SPECIAL_PRI_SHIFT: u32                         = IXGBE_R
 /* SR-IOV specific macros */
 pub fn IXGBE_MBVFICR_INDEX(vf_number: u32) -> u32 { vf_number >> 4 }
 
-pub fn IXGBE_MBVFICR(_i: u32) -> u32 { 0x00710 + ((_i) * 4) }
+pub fn IXGBE_MBVFICR(i: u32) -> u32 { 0x00710 + i * 4 }
 
-pub fn IXGBE_VFLRE(_i: u32) -> u32 { if (_i & 1) != 0 { 0x001C0 } else { 0x00600 } }
+pub fn IXGBE_VFLRE(i: u32) -> u32 { if (i & 1) != 0 { 0x001C0 } else { 0x00600 } }
 
-pub fn IXGBE_VFLREC(_i: u32) -> u32 { 0x00700 + (_i * 4) }
+pub fn IXGBE_VFLREC(i: u32) -> u32 { 0x00700 + i * 4 }
 /* Translated register consts */
-pub fn IXGBE_PVFCTRL(P: u32) -> u32 { 0x00300 + (4 * (P)) }
+pub fn IXGBE_PVFCTRL(P: u32) -> u32 { 0x00300 + 4 * P }
 
-pub fn IXGBE_PVFSTATUS(P: u32) -> u32 { 0x00008 + (0 * (P)) }
+pub fn IXGBE_PVFSTATUS(P: u32) -> u32 { 0x00008 + 0 * P }
 
-pub fn IXGBE_PVFLINKS(P: u32) -> u32 { 0x042A4 + (0 * (P)) }
+pub fn IXGBE_PVFLINKS(P: u32) -> u32 { 0x042A4 + 0 * P }
 
-pub fn IXGBE_PVFRTIMER(P: u32) -> u32 { 0x00048 + (0 * (P)) }
+pub fn IXGBE_PVFRTIMER(P: u32) -> u32 { 0x00048 + 0 * P }
 
-pub fn IXGBE_PVFMAILBOX(P: u32) -> u32 { 0x04C00 + (4 * (P)) }
+pub fn IXGBE_PVFMAILBOX(P: u32) -> u32 { 0x04C00 + 4 * P }
 
-pub fn IXGBE_PVFRXMEMWRAP(P: u32) -> u32 { 0x03190 + (0 * (P)) }
+pub fn IXGBE_PVFRXMEMWRAP(P: u32) -> u32 { 0x03190 + 0 * P }
 
-pub fn IXGBE_PVTEICR(P: u32) -> u32 { 0x00B00 + (4 * (P)) }
+pub fn IXGBE_PVTEICR(P: u32) -> u32 { 0x00B00 + 4 * P }
 
-pub fn IXGBE_PVTEICS(P: u32) -> u32 { 0x00C00 + (4 * (P)) }
+pub fn IXGBE_PVTEICS(P: u32) -> u32 { 0x00C00 + 4 * P }
 
-pub fn IXGBE_PVTEIMS(P: u32) -> u32 { 0x00D00 + (4 * (P)) }
+pub fn IXGBE_PVTEIMS(P: u32) -> u32 { 0x00D00 + 4 * P }
 
-pub fn IXGBE_PVTEIMC(P: u32) -> u32 { 0x00E00 + (4 * (P)) }
+pub fn IXGBE_PVTEIMC(P: u32) -> u32 { 0x00E00 + 4 * P }
 
-pub fn IXGBE_PVTEIAC(P: u32) -> u32 { 0x00F00 + (4 * (P)) }
+pub fn IXGBE_PVTEIAC(P: u32) -> u32 { 0x00F00 + 4 * P }
 
-pub fn IXGBE_PVTEIAM(P: u32) -> u32 { 0x04D00 + (4 * (P)) }
+pub fn IXGBE_PVTEIAM(P: u32) -> u32 { 0x04D00 + 4 * P }
 
-pub fn IXGBE_PVTEITR(P: u32) -> u32 { if P < 24 { 0x00820 + (P * 4) } else { 0x012300 + ((P - 24) * 4) } }
+pub fn IXGBE_PVTEITR(P: u32) -> u32 { if P < 24 { 0x00820 + P * 4 } else { 0x012300 + ((P - 24) * 4) } }
 
-pub fn IXGBE_PVTIVAR(P: u32) -> u32 { 0x12500 + (4 * (P)) }
+pub fn IXGBE_PVTIVAR(P: u32) -> u32 { 0x12500 + 4 * P }
 
-pub fn IXGBE_PVTIVAR_MISC(P: u32) -> u32 { 0x04E00 + (4 * (P)) }
+pub fn IXGBE_PVTIVAR_MISC(P: u32) -> u32 { 0x04E00 + 4 * P }
 
-pub fn IXGBE_PVTRSCINT(P: u32) -> u32 { 0x12000 + (4 * (P)) }
+pub fn IXGBE_PVTRSCINT(P: u32) -> u32 { 0x12000 + 4 * P }
 
-pub fn IXGBE_VFPBACL(P: u32) -> u32 { 0x110C8 + (4 * (P)) }
+pub fn IXGBE_VFPBACL(P: u32) -> u32 { 0x110C8 + 4 * P }
 
-pub fn IXGBE_PVFRDBAL(P: u32) -> u32 { if P < 64 { 0x01000 + (0x40 * P) } else { 0x0D000 + (0x40 * (P - 64)) } }
+pub fn IXGBE_PVFRDBAL(P: u32) -> u32 { if P < 64 { 0x01000 + 0x40 * P } else { 0x0D000 + (0x40 * (P - 64)) } }
 
-pub fn IXGBE_PVFRDBAH(P: u32) -> u32 { if P < 64 { 0x01004 + (0x40 * P) } else { 0x0D004 + (0x40 * (P - 64)) } }
+pub fn IXGBE_PVFRDBAH(P: u32) -> u32 { if P < 64 { 0x01004 + 0x40 * P } else { 0x0D004 + (0x40 * (P - 64)) } }
 
-pub fn IXGBE_PVFRDLEN(P: u32) -> u32 { if P < 64 { 0x01008 + (0x40 * P) } else { 0x0D008 + (0x40 * (P - 64)) } }
+pub fn IXGBE_PVFRDLEN(P: u32) -> u32 { if P < 64 { 0x01008 + 0x40 * P } else { 0x0D008 + (0x40 * (P - 64)) } }
 
-pub fn IXGBE_PVFRDH(P: u32) -> u32 { if P < 64 { 0x01010 + (0x40 * P) } else { 0x0D010 + (0x40 * (P - 64)) } }
+pub fn IXGBE_PVFRDH(P: u32) -> u32 { if P < 64 { 0x01010 + 0x40 * P } else { 0x0D010 + (0x40 * (P - 64)) } }
 
-pub fn IXGBE_PVFRDT(P: u32) -> u32 { if P < 64 { 0x01018 + (0x40 * P) } else { 0x0D018 + (0x40 * (P - 64)) } }
+pub fn IXGBE_PVFRDT(P: u32) -> u32 { if P < 64 { 0x01018 + 0x40 * P } else { 0x0D018 + (0x40 * (P - 64)) } }
 
-pub fn IXGBE_PVFRXDCTL(P: u32) -> u32 { if P < 64 { 0x01028 + (0x40 * P) } else { 0x0D028 + (0x40 * (P - 64)) } }
+pub fn IXGBE_PVFRXDCTL(P: u32) -> u32 { if P < 64 { 0x01028 + 0x40 * P } else { 0x0D028 + (0x40 * (P - 64)) } }
 
-pub fn IXGBE_PVFSRRCTL(P: u32) -> u32 { if P < 64 { 0x01014 + (0x40 * P) } else { 0x0D014 + (0x40 * (P - 64)) } }
+pub fn IXGBE_PVFSRRCTL(P: u32) -> u32 { if P < 64 { 0x01014 + 0x40 * P } else { 0x0D014 + (0x40 * (P - 64)) } }
 
-pub fn IXGBE_PVFPSRTYPE(P: u32) -> u32 { 0x0EA00 + (4 * (P)) }
+pub fn IXGBE_PVFPSRTYPE(P: u32) -> u32 { 0x0EA00 + 4 * P }
 
-pub fn IXGBE_PVFTDBAL(P: u32) -> u32 { 0x06000 + (0x40 * (P)) }
+pub fn IXGBE_PVFTDBAL(P: u32) -> u32 { 0x06000 + 0x40 * P }
 
-pub fn IXGBE_PVFTDBAH(P: u32) -> u32 { 0x06004 + (0x40 * (P)) }
+pub fn IXGBE_PVFTDBAH(P: u32) -> u32 { 0x06004 + 0x40 * P }
 
-pub fn IXGBE_PVFTDLEN(P: u32) -> u32 { 0x06008 + (0x40 * (P)) }
+pub fn IXGBE_PVFTDLEN(P: u32) -> u32 { 0x06008 + 0x40 * P }
 
-pub fn IXGBE_PVFTDH(P: u32) -> u32 { 0x06010 + (0x40 * (P)) }
+pub fn IXGBE_PVFTDH(P: u32) -> u32 { 0x06010 + 0x40 * P }
 
-pub fn IXGBE_PVFTDT(P: u32) -> u32 { 0x06018 + (0x40 * (P)) }
+pub fn IXGBE_PVFTDT(P: u32) -> u32 { 0x06018 + 0x40 * P }
 
-pub fn IXGBE_PVFTXDCTL(P: u32) -> u32 { 0x06028 + (0x40 * (P)) }
+pub fn IXGBE_PVFTXDCTL(P: u32) -> u32 { 0x06028 + 0x40 * P }
 
-pub fn IXGBE_PVFTDWBAL(P: u32) -> u32 { 0x06038 + (0x40 * (P)) }
+pub fn IXGBE_PVFTDWBAL(P: u32) -> u32 { 0x06038 + 0x40 * P }
 
-pub fn IXGBE_PVFTDWBAH(P: u32) -> u32 { 0x0603C + (0x40 * (P)) }
+pub fn IXGBE_PVFTDWBAH(P: u32) -> u32 { 0x0603C + 0x40 * P }
 
 pub fn IXGBE_PVFDCA_RXCTRL(P: u32) -> u32 { if P < 64 { 0x0100C + 0x40 * P } else { 0x0D00C + 0x40 * (P - 64) } }
-pub fn IXGBE_PVFDCA_TXCTRL(P: u32) -> u32 { 0x0600C + (0x40 * (P)) }
+pub fn IXGBE_PVFDCA_TXCTRL(P: u32) -> u32 { 0x0600C + 0x40 * P }
 
-pub fn IXGBE_PVFGPRC(x: u32) -> u32 { 0x0101C + (0x40 * (x)) }
+pub fn IXGBE_PVFGPRC(x: u32) -> u32 { 0x0101C + 0x40 * x }
 
-pub fn IXGBE_PVFGPTC(x: u32) -> u32 { 0x08300 + (0x04 * (x)) }
+pub fn IXGBE_PVFGPTC(x: u32) -> u32 { 0x08300 + 0x04 * x }
 
-pub fn IXGBE_PVFGORC_LSB(x: u32) -> u32 { 0x01020 + (0x40 * (x)) }
+pub fn IXGBE_PVFGORC_LSB(x: u32) -> u32 { 0x01020 + 0x40 * x }
 
-pub fn IXGBE_PVFGORC_MSB(x: u32) -> u32 { 0x0D020 + (0x40 * (x)) }
+pub fn IXGBE_PVFGORC_MSB(x: u32) -> u32 { 0x0D020 + 0x40 * x }
 
-pub fn IXGBE_PVFGOTC_LSB(x: u32) -> u32 { 0x08400 + (0x08 * (x)) }
+pub fn IXGBE_PVFGOTC_LSB(x: u32) -> u32 { 0x08400 + 0x08 * x }
 
-pub fn IXGBE_PVFGOTC_MSB(x: u32) -> u32 { 0x08404 + (0x08 * (x)) }
+pub fn IXGBE_PVFGOTC_MSB(x: u32) -> u32 { 0x08404 + 0x08 * x }
 
-pub fn IXGBE_PVFMPRC(x: u32) -> u32 { 0x0D01C + (0x40 * (x)) }
+pub fn IXGBE_PVFMPRC(x: u32) -> u32 { 0x0D01C + 0x40 * x }
 
 pub fn IXGBE_PVFTDWBALn(q_per_pool: u32, vf_number: u32, vf_q_index: u32) -> u32 { IXGBE_PVFTDWBAL((q_per_pool) * (vf_number) + (vf_q_index)) }
 
@@ -2990,7 +2990,8 @@ pub fn IXGBE_PVFTDHn(q_per_pool: u32, vf_number: u32, vf_q_index: u32) -> u32 { 
 
 pub fn IXGBE_PVFTDTn(q_per_pool: u32, vf_number: u32, vf_q_index: u32) -> u32 { IXGBE_PVFTDT((q_per_pool) * (vf_number) + (vf_q_index)) }
 
-
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub enum ixgbe_fdir_pballoc_type {
     IXGBE_FDIR_PBALLOC_NONE                                            = 0,
     IXGBE_FDIR_PBALLOC_64K                                             = 1,
@@ -3122,7 +3123,7 @@ pub const FW_PHY_TOKEN_OK: u32                                         = 1;
 pub const FW_PHY_TOKEN_RETRY: u32                                      = 0x80;
 pub const FW_PHY_TOKEN_DELAY: u32                                      = 5;    /* milliseconds */
 pub const FW_PHY_TOKEN_WAIT: u32                                       = 5;    /* seconds */
-pub fn FW_PHY_TOKEN_RETRIES() -> u32 { (FW_PHY_TOKEN_WAIT * 1000) / FW_PHY_TOKEN_DELAY }
+pub fn FW_PHY_TOKEN_RETRIES() -> u32 { FW_PHY_TOKEN_WAIT * 1000 / FW_PHY_TOKEN_DELAY }
 
 pub const FW_INT_PHY_REQ_CMD: u32                                      = 0xB;
 pub const FW_INT_PHY_REQ_LEN: u32                                      = 10;
@@ -3607,7 +3608,7 @@ pub const IXGBE_PHYSICAL_LAYER_2500BASE_KX: u32                        = 0x10000
  */
 
 /* BitTimes (BT) conversion */
-pub fn IXGBE_BT2KB(BT: u32) -> u32 { (BT + (8 * 1024 - 1)) / (8 * 1024) }
+pub fn IXGBE_BT2KB(BT: u32) -> u32 { (BT + (8 * 1024 - 1)) / 8 * 1024 }
 
 pub fn IXGBE_B2BT(BT: u32) -> u32 { BT * 8 }
 
@@ -3639,15 +3640,15 @@ pub const IXGBE_HD: u32                                                = 6144;
 pub const IXGBE_PCI_DELAY: u32                                         = 10000;
 
 /* Calculate X540 delay value in bit times */
-pub fn IXGBE_DV_X540(_max_frame_link: u32, _max_frame_tc: u32) -> u32 { (36 * (IXGBE_B2BT(_max_frame_link) + IXGBE_PFC_D + (2 * IXGBE_CABLE_DC) + (2 * IXGBE_ID_X540) + IXGBE_HD) / 25 + 1) + 2 * IXGBE_B2BT(_max_frame_tc) }
+pub fn IXGBE_DV_X540(max_frame_link: u32, max_frame_tc: u32) -> u32 { (36 * (IXGBE_B2BT(max_frame_link) + IXGBE_PFC_D + 2 * IXGBE_CABLE_DC + 2 * IXGBE_ID_X540 + IXGBE_HD) / 25 + 1) + 2 * IXGBE_B2BT(max_frame_tc) }
 
 /* Calculate 82599, 82598 delay value in bit times */
-pub fn IXGBE_DV(_max_frame_link: u32, _max_frame_tc: u32) -> u32 { (36 * (IXGBE_B2BT(_max_frame_link) + IXGBE_PFC_D + (2 * IXGBE_CABLE_DC) + (2 * IXGBE_ID) + IXGBE_HD) / 25 + 1) + 2 * IXGBE_B2BT(_max_frame_tc) }
+pub fn IXGBE_DV(max_frame_link: u32, max_frame_tc: u32) -> u32 { (36 * (IXGBE_B2BT(max_frame_link) + IXGBE_PFC_D + 2 * IXGBE_CABLE_DC + 2 * IXGBE_ID + IXGBE_HD) / 25 + 1) + 2 * IXGBE_B2BT(max_frame_tc) }
 
 /* Calculate low threshold delay values */
-pub fn IXGBE_LOW_DV_X540(_max_frame_tc: u32) -> u32 { 2 * IXGBE_B2BT(_max_frame_tc) + (36 * IXGBE_PCI_DELAY / 25) + 1 }
+pub fn IXGBE_LOW_DV_X540(max_frame_tc: u32) -> u32 { 2 * IXGBE_B2BT(max_frame_tc) + (36 * IXGBE_PCI_DELAY / 25) + 1 }
 
-pub fn IXGBE_LOW_DV(_max_frame_tc: u32) -> u32 { 2 * IXGBE_LOW_DV_X540(_max_frame_tc) }
+pub fn IXGBE_LOW_DV(max_frame_tc: u32) -> u32 { 2 * IXGBE_LOW_DV_X540(max_frame_tc) }
 
 /* Software ATR hash keys */
 pub const IXGBE_ATR_BUCKET_HASH_KEY: u32                               = 0x3DAD14E2;
@@ -3662,6 +3663,8 @@ pub const IXGBE_ATR_L4TYPE_SCTP: u32                                   = 0x3;
 pub const IXGBE_ATR_L4TYPE_IPV6_MASK: u32                              = 0x4;
 pub const IXGBE_ATR_L4TYPE_TUNNEL_MASK: u32                            = 0x10;
 
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub enum ixgbe_atr_flow_type {
     IXGBE_ATR_FLOW_TYPE_IPV4                                           = 0x0,
     IXGBE_ATR_FLOW_TYPE_UDPV4                                          = 0x1,
@@ -3754,14 +3757,16 @@ union ixgbe_atr_hash_dword {
  * Disabled: Present; boot order is not set for any targets on the port.
  * Enabled: Present; boot order is set for at least one target on the port.
  */
-#[derive(Copy, Clone)]
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub enum ixgbe_fcoe_boot_status {
     IXGbe_fcoe_bootstatus_disabled    = 0,
     IXGbe_fcoe_bootstatus_enabled     = 1,
     IXGbe_fcoe_bootstatus_unavailable = 0xFFFF,
 }
 
-#[derive(Copy, Clone)]
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub enum ixgbe_eeprom_type {
     IXGbe_eeprom_uninitialized        = 0,
     IXGbe_eeprom_spi,
@@ -3770,7 +3775,8 @@ pub enum ixgbe_eeprom_type {
     /* No NVM support */
 }
 
-#[derive(Copy, Clone)]
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub enum ixgbe_mac_type {
     IXGbe_mac_unknown                 = 0,
     IXGbe_mac_82598EB,
@@ -3787,7 +3793,8 @@ pub enum ixgbe_mac_type {
     IXGbe_num_macs,
 }
 
-#[derive(Copy, Clone)]
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub enum ixgbe_phy_type {
     IXGbe_phy_unknown                 = 0,
     IXGbe_phy_none,
@@ -3834,7 +3841,8 @@ pub enum ixgbe_phy_type {
  * 5	SFP_SR/LR_CORE0 - 82599-specific;
  * 6	SFP_SR/LR_CORE1 - 82599-specific;
  */
-#[derive(Copy, Clone)]
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub enum ixgbe_sfp_type {
     IXGbe_sfp_type_da_cu              =  0,
     IXGbe_sfp_type_sr                 =  1,
@@ -3855,7 +3863,8 @@ pub enum ixgbe_sfp_type {
     IXGbe_sfp_type_unknown            = 0xFFFF,
 }
 
-#[derive(Copy, Clone)]
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub enum ixgbe_media_type {
     IXGbe_media_type_unknown          = 0,
     IXGbe_media_type_fiber,
@@ -3868,6 +3877,7 @@ pub enum ixgbe_media_type {
 }
 
 /* Flow Control Settings */
+#[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub enum ixgbe_fc_mode {
     IXGbe_fc_none                     = 0,
@@ -3880,7 +3890,8 @@ pub enum ixgbe_fc_mode {
 /* Smart Speed Settings */
 pub const IXGBE_SMARTSPEED_MAX_RETRIES: u32                            = 3;
 
-#[derive(Copy, Clone)]
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub enum ixgbe_smart_speed {
     IXGbe_smart_speed_auto            = 0,
     IXGbe_smart_speed_on,
@@ -3888,6 +3899,7 @@ pub enum ixgbe_smart_speed {
 }
 
 /* PCI bus types */
+#[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub enum ixgbe_bus_type {
     IXGbe_bus_type_unknown            = 0,
@@ -3899,6 +3911,7 @@ pub enum ixgbe_bus_type {
 }
 
 /* PCI bus speeds */
+#[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub enum ixgbe_bus_speed {
     IXGbe_bus_speed_unknown           = 0,
@@ -3914,6 +3927,7 @@ pub enum ixgbe_bus_speed {
 }
 
 /* PCI bus widths */
+#[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub enum ixgbe_bus_width {
     IXGbe_bus_width_unknown           = 0,
@@ -4057,7 +4071,7 @@ pub struct ixgbe_hw_stats {
 // functions removed
 
 
-pub fn IXGBE_FUSES0_GROUP(_i: u32) -> u32 { 0x11158 + ((_i) * 4) }
+pub fn IXGBE_FUSES0_GROUP(i: u32) -> u32 { 0x11158 + i * 4 }
 
 pub const IXGBE_FUSES0_300MHZ: u32                                     = 1 << 5;
 pub const IXGBE_FUSES0_REV_MASK: u32                                   = 3 << 6;

--- a/src/ixgbe.rs
+++ b/src/ixgbe.rs
@@ -18,9 +18,10 @@ use crate::vfio::VFIO_PCI_BAR0_REGION_INDEX;
 use crate::DeviceStats;
 use crate::Interrupts;
 use crate::IxyDevice;
-use crate::MAX_QUEUES;
 
 const DRIVER_NAME: &str = "ixy-ixgbe";
+
+const MAX_QUEUES: u16 = 64;
 
 const PKT_BUF_ENTRY_SIZE: usize = 2048;
 const MIN_MEMPOOL_SIZE: usize = 4096;

--- a/src/ixgbevf.rs
+++ b/src/ixgbevf.rs
@@ -16,10 +16,11 @@ use crate::memory::*;
 use crate::pci::pci_map_resource;
 use crate::DeviceStats;
 use crate::IxyDevice;
-use crate::MAX_QUEUES;
 use std::cmp::min;
 
 const DRIVER_NAME: &str = "ixy-ixgbevf";
+
+const MAX_QUEUES: u16 = 8;
 
 const PKT_BUF_ENTRY_SIZE: usize = 2048;
 const MIN_MEMPOOL_SIZE: usize = 4096;
@@ -113,7 +114,6 @@ impl IxyDevice for IxgbeVFDevice {
             warn!("not running as root, this will probably fail");
         }
 
-        // FIXME: what is the maximum number of queues for VFs?
         assert!(
             num_rx_queues <= MAX_QUEUES,
             "cannot configure {} rx queues: limit is {}",
@@ -470,7 +470,7 @@ impl IxgbeVFDevice {
 
         self.set_reg32(IXGBE_VFPSRTYPE, 0);
 
-        for i in 0..7 {
+        for i in 0..(MAX_QUEUES as u32) {
             self.set_reg32(IXGBE_VFRDH(i), 0);
             self.set_reg32(IXGBE_VFRDT(i), 0);
             self.set_reg32(IXGBE_VFRXDCTL(i), 0);

--- a/src/ixgbevf.rs
+++ b/src/ixgbevf.rs
@@ -1,0 +1,1103 @@
+use std::cell::RefCell;
+use std::collections::VecDeque;
+use std::error::Error;
+use std::fs::File;
+use std::io::Read;
+use std::mem;
+use std::os::unix::io::RawFd;
+use std::ptr;
+use std::rc::Rc;
+use std::thread;
+use std::time::Duration;
+
+use crate::constants::*;
+use crate::memory::*;
+
+use crate::pci::pci_map_resource;
+use crate::DeviceStats;
+use crate::IxyDevice;
+use crate::MAX_QUEUES;
+use std::cmp::min;
+
+const DRIVER_NAME: &str = "ixy-ixgbevf";
+
+const PKT_BUF_ENTRY_SIZE: usize = 2048;
+const MIN_MEMPOOL_SIZE: usize = 4096;
+
+const NUM_RX_QUEUE_ENTRIES: usize = 512;
+const NUM_TX_QUEUE_ENTRIES: usize = 512;
+const TX_CLEAN_BATCH: usize = 32;
+
+fn wrap_ring(index: usize, ring_size: usize) -> usize {
+    (index + 1) & (ring_size - 1)
+}
+
+pub struct Mailbox {
+    api_version: ixgbe_pfvf_api_rev,
+
+    timeout: u32,
+    usec_delay: u32,
+    v2p_mailbox: u32,
+    size: u16,
+
+    // stats
+    msgs_tx: u32,
+    msgs_rx: u32,
+    reqs: u32,
+    acks: u32,
+    rsts: u32,
+}
+
+impl Mailbox {
+    fn init() -> Self {
+        Mailbox {
+            api_version: ixgbe_pfvf_api_rev::ixgbe_mbox_api_10,
+
+            timeout: IXGBE_VF_MBX_INIT_TIMEOUT,
+            usec_delay: IXGBE_VF_MBX_INIT_DELAY,
+            v2p_mailbox: 0,
+            size: IXGBE_VFMAILBOX_SIZE,
+
+            // stats
+            msgs_tx: 0,
+            msgs_rx: 0,
+            reqs: 0,
+            acks: 0,
+            rsts: 0,
+        }
+    }
+}
+
+pub struct IxgbeVFDevice {
+    pci_addr: String,
+    addr: *mut u8,
+    len: usize,
+    num_rx_queues: u16,
+    num_tx_queues: u16,
+    rx_queues: Vec<IxgbeRxQueue>,
+    tx_queues: Vec<IxgbeTxQueue>,
+    mbx: RefCell<Mailbox>,
+    mac: RefCell<[u8; 6]>,
+    stats: RefCell<DeviceStats>,
+}
+
+struct IxgbeRxQueue {
+    descriptors: *mut ixgbe_adv_rx_desc,
+    num_descriptors: usize,
+    pool: Rc<Mempool>,
+    bufs_in_use: Vec<usize>,
+    rx_index: usize,
+}
+
+struct IxgbeTxQueue {
+    descriptors: *mut ixgbe_adv_tx_desc,
+    num_descriptors: usize,
+    pool: Option<Rc<Mempool>>,
+    bufs_in_use: VecDeque<usize>,
+    clean_index: usize,
+    tx_index: usize,
+}
+
+impl IxyDevice for IxgbeVFDevice {
+    /// Returns an initialized `IxgbeDevice` on success.
+    ///
+    /// # Panics
+    /// Panics if `num_rx_queues` or `num_tx_queues` exceeds `MAX_QUEUES`.
+    fn init(
+        pci_addr: &str,
+        num_rx_queues: u16,
+        num_tx_queues: u16,
+        _interrupt_timeout: i16,
+    ) -> Result<IxgbeVFDevice, Box<dyn Error>> {
+        if unsafe { libc::getuid() } != 0 {
+            warn!("not running as root, this will probably fail");
+        }
+
+        // FIXME: what is the maximum number of queues for VFs?
+        assert!(
+            num_rx_queues <= MAX_QUEUES,
+            "cannot configure {} rx queues: limit is {}",
+            num_rx_queues,
+            MAX_QUEUES
+        );
+        assert!(
+            num_tx_queues <= MAX_QUEUES,
+            "cannot configure {} tx queues: limit is {}",
+            num_tx_queues,
+            MAX_QUEUES
+        );
+
+        let (addr, len) = pci_map_resource(pci_addr)?;
+
+        // initialize RX and TX queue
+        let rx_queues = Vec::with_capacity(num_rx_queues as usize);
+        let tx_queues = Vec::with_capacity(num_tx_queues as usize);
+
+        let mbx = RefCell::new(Mailbox::init());
+        let mac = RefCell::new([0; 6]);
+        let stats = RefCell::new(DeviceStats::default());
+
+        // create the IxyDevice
+        let mut dev = IxgbeVFDevice {
+            pci_addr: pci_addr.to_string(),
+            addr,
+            len,
+            num_rx_queues,
+            num_tx_queues,
+            rx_queues,
+            tx_queues,
+            mbx,
+            mac,
+            stats,
+        };
+
+        dev.reset_and_init(pci_addr)?;
+
+        Ok(dev)
+    }
+
+    /// Returns the driver's name of this device.
+    fn get_driver_name(&self) -> &str {
+        DRIVER_NAME
+    }
+
+    /// Returns the card's iommu capability.
+    fn is_card_iommu_capable(&self) -> bool {
+        false
+    }
+
+    /// Returns VFIO container file descriptor or [`None`] if IOMMU is not available.
+    fn get_vfio_container(&self) -> Option<RawFd> {
+        None
+    }
+
+    /// Returns the pci address of this device.
+    fn get_pci_addr(&self) -> &str {
+        &self.pci_addr
+    }
+
+    /// Returns the mac address of this device.
+    fn get_mac_addr(&self) -> [u8; 6] {
+        *self.mac.borrow()
+    }
+
+    /// Sets the mac address of this device.
+    fn set_mac_addr(&self, mac: [u8; 6]) {
+        let mut msg = [IXGBE_VF_SET_MAC_ADDR, 0, 0];
+
+        msg[1] = u32::from(mac[0])
+            + (u32::from(mac[1]) << 8)
+            + (u32::from(mac[2]) << 16)
+            + (u32::from(mac[3]) << 24);
+        msg[2] = u32::from(mac[4]) + (u32::from(mac[5]) << 8);
+
+        self.wait_write_read_msg_mbx(&mut msg).unwrap();
+
+        msg[0] &= !IXGBE_VT_MSGTYPE_CTS;
+
+        if msg[0] == (IXGBE_VF_SET_MAC_ADDR | IXGBE_VT_MSGTYPE_NACK) {
+            warn!("mac address rejected by device");
+        }
+    }
+
+    /// Pushes up to `num_packets` received `Packet`s onto `buffer`.
+    fn rx_batch(
+        &mut self,
+        queue_id: u32,
+        buffer: &mut VecDeque<Packet>,
+        num_packets: usize,
+    ) -> usize {
+        let mut rx_index;
+        let mut last_rx_index;
+        let mut received_packets = 0;
+
+        {
+            let queue = self
+                .rx_queues
+                .get_mut(queue_id as usize)
+                .expect("invalid rx queue id");
+
+            rx_index = queue.rx_index;
+            last_rx_index = queue.rx_index;
+
+            for i in 0..num_packets {
+                let desc = unsafe { queue.descriptors.add(rx_index) as *mut ixgbe_adv_rx_desc };
+                let status =
+                    unsafe { ptr::read_volatile(&mut (*desc).wb.upper.status_error as *mut u32) };
+
+                if (status & IXGBE_RXDADV_STAT_DD) == 0 {
+                    break;
+                }
+
+                if (status & IXGBE_RXDADV_STAT_EOP) == 0 {
+                    panic!("increase buffer size or decrease MTU")
+                }
+
+                let pool = &queue.pool;
+
+                // get a free buffer from the mempool
+                if let Some(buf) = pool.alloc_buf() {
+                    // replace currently used buffer with new buffer
+                    let buf = mem::replace(&mut queue.bufs_in_use[rx_index], buf);
+
+                    let p = Packet {
+                        addr_virt: pool.get_virt_addr(buf),
+                        addr_phys: pool.get_phys_addr(buf),
+                        len: unsafe {
+                            ptr::read_volatile(&(*desc).wb.upper.length as *const u16) as usize
+                        },
+                        pool: pool.clone(),
+                        pool_entry: buf,
+                    };
+
+                    #[cfg(all(
+                        any(target_arch = "x86", target_arch = "x86_64"),
+                        target_feature = "sse"
+                    ))]
+                    p.prefetch(Prefetch::Time1);
+
+                    buffer.push_back(p);
+
+                    unsafe {
+                        ptr::write_volatile(
+                            &mut (*desc).read.pkt_addr as *mut u64,
+                            pool.get_phys_addr(queue.bufs_in_use[rx_index]) as u64,
+                        );
+                        ptr::write_volatile(&mut (*desc).read.hdr_addr as *mut u64, 0);
+                    }
+
+                    last_rx_index = rx_index;
+                    rx_index = wrap_ring(rx_index, queue.num_descriptors);
+                    received_packets = i + 1;
+                } else {
+                    // break if there was no free buffer
+                    break;
+                }
+            }
+        }
+
+        if rx_index != last_rx_index {
+            self.set_reg32(IXGBE_VFRDT(queue_id), last_rx_index as u32);
+            self.rx_queues[queue_id as usize].rx_index = rx_index;
+        }
+
+        received_packets
+    }
+
+    /// Pops as many packets as possible from `packets` to put them into the device`s tx queue.
+    fn tx_batch(&mut self, queue_id: u32, packets: &mut VecDeque<Packet>) -> usize {
+        let mut sent = 0;
+
+        {
+            let mut queue = self
+                .tx_queues
+                .get_mut(queue_id as usize)
+                .expect("invalid tx queue id");
+
+            let mut cur_index = queue.tx_index;
+            let clean_index = clean_tx_queue(&mut queue);
+
+            if queue.pool.is_none() {
+                if let Some(packet) = packets.get(0) {
+                    queue.pool = Some(packet.pool.clone());
+                }
+            }
+
+            while let Some(packet) = packets.pop_front() {
+                assert!(
+                    Rc::ptr_eq(queue.pool.as_ref().unwrap(), &packet.pool),
+                    "distinct memory pools for a single tx queue are not supported yet"
+                );
+
+                let next_index = wrap_ring(cur_index, queue.num_descriptors);
+
+                if clean_index == next_index {
+                    // tx queue of device is full, push packet back onto the
+                    // queue of to-be-sent packets
+                    packets.push_front(packet);
+                    break;
+                }
+
+                queue.tx_index = wrap_ring(queue.tx_index, queue.num_descriptors);
+
+                unsafe {
+                    ptr::write_volatile(
+                        &mut (*queue.descriptors.add(cur_index)).read.buffer_addr as *mut u64,
+                        packet.get_phys_addr() as u64,
+                    );
+                    ptr::write_volatile(
+                        &mut (*queue.descriptors.add(cur_index)).read.cmd_type_len as *mut u32,
+                        IXGBE_ADVTXD_DCMD_EOP
+                            | IXGBE_ADVTXD_DCMD_RS
+                            | IXGBE_ADVTXD_DCMD_IFCS
+                            | IXGBE_ADVTXD_DCMD_DEXT
+                            | IXGBE_ADVTXD_DTYP_DATA
+                            | packet.len() as u32,
+                    );
+                    ptr::write_volatile(
+                        &mut (*queue.descriptors.add(cur_index)).read.olinfo_status as *mut u32,
+                        (packet.len() as u32) << IXGBE_ADVTXD_PAYLEN_SHIFT,
+                    );
+                }
+
+                queue.bufs_in_use.push_back(packet.pool_entry);
+                mem::forget(packet);
+
+                cur_index = next_index;
+                sent += 1;
+            }
+        }
+
+        self.set_reg32(
+            IXGBE_VFTDT(queue_id),
+            self.tx_queues[queue_id as usize].tx_index as u32,
+        );
+
+        sent
+    }
+
+    /// Reads the stats of this device into `stats`.
+    fn read_stats(&self, stats: &mut DeviceStats) {
+        let mut dev_stats = self.stats.borrow_mut();
+
+        let rx_pkts = u64::from(self.get_reg32(IXGBE_VFGPRC));
+        let tx_pkts = u64::from(self.get_reg32(IXGBE_VFGPTC));
+        let rx_bytes = u64::from(self.get_reg32(IXGBE_VFGORC_LSB))
+            + (u64::from(self.get_reg32(IXGBE_VFGORC_MSB)) << 32);
+        let tx_bytes = u64::from(self.get_reg32(IXGBE_VFGOTC_LSB))
+            + (u64::from(self.get_reg32(IXGBE_VFGOTC_MSB)) << 32);
+
+        // stat registers wrap around, pkts have a 32 bit and bytes a 36 bit counter
+        stats.rx_pkts += rx_pkts.wrapping_sub(dev_stats.rx_pkts) & ((1 << 32) - 1);
+        stats.tx_pkts += tx_pkts.wrapping_sub(dev_stats.tx_pkts) & ((1 << 32) - 1);
+        stats.rx_bytes += rx_bytes.wrapping_sub(dev_stats.rx_bytes) & ((1 << 36) - 1);
+        stats.tx_bytes += tx_bytes.wrapping_sub(dev_stats.tx_bytes) & ((1 << 36) - 1);
+
+        dev_stats.rx_pkts = rx_pkts;
+        dev_stats.tx_pkts = tx_pkts;
+        dev_stats.rx_bytes = rx_bytes;
+        dev_stats.tx_bytes = tx_bytes;
+    }
+
+    /// Resets the stats of this device.
+    fn reset_stats(&mut self) {
+        let mut dev_stats = self.stats.borrow_mut();
+
+        dev_stats.rx_pkts = u64::from(self.get_reg32(IXGBE_VFGPRC));
+        dev_stats.tx_pkts = u64::from(self.get_reg32(IXGBE_VFGPTC));
+        dev_stats.rx_bytes = u64::from(self.get_reg32(IXGBE_VFGORC_LSB))
+            + (u64::from(self.get_reg32(IXGBE_VFGORC_MSB)) << 32);
+        dev_stats.tx_bytes = u64::from(self.get_reg32(IXGBE_VFGOTC_LSB))
+            + (u64::from(self.get_reg32(IXGBE_VFGOTC_MSB)) << 32);
+    }
+
+    /// Returns the link speed of this device.
+    fn get_link_speed(&self) -> u16 {
+        let speed = self.get_reg32(IXGBE_VFLINKS);
+        if (speed & IXGBE_LINKS_UP) == 0 {
+            return 0;
+        }
+        match speed & IXGBE_LINKS_SPEED_82599 {
+            IXGBE_LINKS_SPEED_100_82599 => 100,
+            IXGBE_LINKS_SPEED_1G_82599 => 1000,
+            IXGBE_LINKS_SPEED_10G_82599 => 10000,
+            _ => 0,
+        }
+    }
+}
+
+impl IxgbeVFDevice {
+    /// Resets and initializes this device.
+    fn reset_and_init(&mut self, pci_addr: &str) -> Result<(), Box<dyn Error>> {
+        info!("resetting device {}", pci_addr);
+
+        // disable all interrupts
+        self.disable_interrupts();
+
+        // reset VF
+        self.set_reg32(IXGBE_VFCTRL, IXGBE_CTRL_RST);
+        self.get_reg32(IXGBE_STATUS);
+        thread::sleep(Duration::from_millis(50));
+
+        // cannot reset while the RSTI / RSTD bits are asserted
+        self.wait_check_for_rst()?;
+
+        // DPDK does this, probably something we could leave out
+        self.reset_vf_registers();
+
+        self.wait_write_msg_to_mbx(&[IXGBE_VF_RESET])?;
+        thread::sleep(Duration::from_millis(10));
+
+        info!("initializing device {}", pci_addr);
+
+        self.init_mac_addr()?;
+
+        self.negotiate_api()?;
+
+        self.init_tx()?;
+
+        self.init_rx()?;
+
+        for i in 0..self.num_tx_queues {
+            self.start_tx_queue(i)?;
+        }
+
+        for i in 0..self.num_rx_queues {
+            self.start_rx_queue(i)?;
+        }
+
+        // setup done, what is our link speed?
+        info!("link speed is {} Mbit/s", self.get_link_speed());
+
+        Ok(())
+    }
+
+    /// Resets the VF registers.
+    fn reset_vf_registers(&mut self) {
+        // VRSRRCTL default values (BSIZEPACKET = 2048, BSIZEHEADER = 256)
+        let mut vfsrrctl = 0x100 << IXGBE_SRRCTL_BSIZEHDRSIZE_SHIFT;
+        vfsrrctl |= 0x800 >> IXGBE_SRRCTL_BSIZEPKT_SHIFT;
+
+        // DCA_RXCTRL default value
+        let vfdca_rxctrl = IXGBE_DCA_RXCTRL_DESC_RRO_EN
+            | IXGBE_DCA_RXCTRL_DATA_WRO_EN
+            | IXGBE_DCA_RXCTRL_HEAD_WRO_EN;
+
+        // DCA_TXCTRL default value
+        let vfdca_txctrl = IXGBE_DCA_TXCTRL_DESC_RRO_EN
+            | IXGBE_DCA_TXCTRL_DESC_WRO_EN
+            | IXGBE_DCA_TXCTRL_DATA_RRO_EN;
+
+        self.set_reg32(IXGBE_VFPSRTYPE, 0);
+
+        for i in 0..7 {
+            self.set_reg32(IXGBE_VFRDH(i), 0);
+            self.set_reg32(IXGBE_VFRDT(i), 0);
+            self.set_reg32(IXGBE_VFRXDCTL(i), 0);
+            self.set_reg32(IXGBE_VFSRRCTL(i), vfsrrctl);
+            self.set_reg32(IXGBE_VFTDH(i), 0);
+            self.set_reg32(IXGBE_VFTDT(i), 0);
+            self.set_reg32(IXGBE_VFTXDCTL(i), 0);
+            self.set_reg32(IXGBE_VFTDWBAH(i), 0);
+            self.set_reg32(IXGBE_VFTDWBAL(i), 0);
+            self.set_reg32(IXGBE_VFDCA_RXCTRL(i), vfdca_rxctrl);
+            self.set_reg32(IXGBE_VFDCA_TXCTRL(i), vfdca_txctrl);
+        }
+
+        self.get_reg32(IXGBE_STATUS);
+    }
+
+    /// Negotiates the mailbox API version.
+    fn negotiate_api(&mut self) -> Result<(), Box<dyn Error>> {
+        let api_versions = [
+            ixgbe_pfvf_api_rev::ixgbe_mbox_api_13,
+            ixgbe_pfvf_api_rev::ixgbe_mbox_api_12,
+            ixgbe_pfvf_api_rev::ixgbe_mbox_api_11,
+            ixgbe_pfvf_api_rev::ixgbe_mbox_api_10,
+        ];
+
+        for api_version in &api_versions {
+            let mut msg = [IXGBE_VF_API_NEGOTIATE, *api_version as u32, 0];
+
+            self.wait_write_read_msg_mbx(&mut msg)?;
+
+            msg[0] &= !IXGBE_VT_MSGTYPE_CTS;
+
+            if msg[0] == (IXGBE_VF_API_NEGOTIATE | IXGBE_VT_MSGTYPE_ACK) {
+                self.mbx.borrow_mut().api_version = *api_version;
+                break;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Initializes the mac address of this device appropriately, i.e. by
+    /// using the PF set mac address or generating a new one.
+    fn init_mac_addr(&mut self) -> Result<(), Box<dyn Error>> {
+        // permanent address
+        let mut msg_buf = [3; IXGBE_VF_PERMADDR_MSG_LEN as usize];
+        self.wait_read_msg_from_mbx(&mut msg_buf)?;
+
+        if msg_buf[0] != (IXGBE_VF_RESET | IXGBE_VT_MSGTYPE_ACK)
+            && msg_buf[0] != (IXGBE_VF_RESET | IXGBE_VT_MSGTYPE_NACK)
+        {
+            return Err("invalid mac address".into());
+        }
+
+        if msg_buf[0] == (IXGBE_VF_RESET | IXGBE_VT_MSGTYPE_ACK) {
+            let mut mac = self.mac.borrow_mut();
+
+            mac[0] = (msg_buf[1] >> 24) as u8;
+            mac[1] = (msg_buf[1] >> 16 & 0xff) as u8;
+            mac[2] = (msg_buf[1] >> 8 & 0xff) as u8;
+            mac[3] = (msg_buf[1] & 0xff) as u8;
+            mac[4] = (msg_buf[2] >> 8 & 0xff) as u8;
+            mac[5] = (msg_buf[2] & 0xff) as u8;
+
+            info!(
+                "received mac address from PF driver: {:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}",
+                mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]
+            );
+        } else {
+            let mut mac = self.mac.borrow_mut();
+
+            mac[0] = 0x02; // indicates locally assigned mac address
+            mac[1] = 0x09;
+            mac[2] = 0xC0;
+
+            // generate last 3 bytes of mac address randomly
+            File::open("/dev/urandom")?.read_exact(&mut mac[3..])?;
+
+            info!(
+                "generated mac address: {:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}",
+                mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]
+            );
+
+            self.set_mac_addr(*mac);
+        }
+
+        Ok(())
+    }
+
+    // sections 4.6.7
+    /// Initializes the rx queues of this device.
+    fn init_rx(&mut self) -> Result<(), Box<dyn Error>> {
+        // configure queues, same for all queues
+        for i in 0..self.num_rx_queues {
+            debug!("initializing rx queue {}", i);
+            // enable advanced rx descriptors
+            self.set_reg32(
+                IXGBE_VFSRRCTL(u32::from(i)),
+                (self.get_reg32(IXGBE_VFSRRCTL(u32::from(i))) & !IXGBE_SRRCTL_DESCTYPE_MASK)
+                    | IXGBE_SRRCTL_DESCTYPE_ADV_ONEBUF,
+            );
+            // let nic drop packets if no rx descriptor is available instead of buffering them
+            self.set_flags32(IXGBE_VFSRRCTL(u32::from(i)), IXGBE_SRRCTL_DROP_EN);
+
+            // section 7.1.9 - setup descriptor ring
+            let ring_size_bytes =
+                (NUM_RX_QUEUE_ENTRIES) as usize * mem::size_of::<ixgbe_adv_rx_desc>();
+
+            let dma: Dma<ixgbe_adv_rx_desc> = Dma::allocate(ring_size_bytes, true)?;
+
+            // initialize to 0xff to prevent rogue memory accesses on premature dma activation
+            unsafe {
+                memset(dma.virt as *mut u8, ring_size_bytes, 0xff);
+            }
+
+            self.set_reg32(
+                IXGBE_VFRDBAL(u32::from(i)),
+                (dma.phys as u64 & 0xffff_ffff) as u32,
+            );
+            self.set_reg32(IXGBE_VFRDBAH(u32::from(i)), (dma.phys as u64 >> 32) as u32);
+            self.set_reg32(IXGBE_VFRDLEN(u32::from(i)), ring_size_bytes as u32);
+
+            debug!("rx ring {} phys addr: {:#x}", i, dma.phys);
+            debug!("rx ring {} virt addr: {:p}", i, dma.virt);
+
+            // set ring to empty at start
+            self.set_reg32(IXGBE_VFRDH(u32::from(i)), 0);
+            self.set_reg32(IXGBE_VFRDT(u32::from(i)), 0);
+
+            let mempool_size = if NUM_RX_QUEUE_ENTRIES + NUM_TX_QUEUE_ENTRIES < MIN_MEMPOOL_SIZE {
+                MIN_MEMPOOL_SIZE
+            } else {
+                NUM_RX_QUEUE_ENTRIES + NUM_TX_QUEUE_ENTRIES
+            };
+
+            let mempool = Mempool::allocate(mempool_size as usize, PKT_BUF_ENTRY_SIZE).unwrap();
+
+            let rx_queue = IxgbeRxQueue {
+                descriptors: dma.virt,
+                pool: mempool,
+                num_descriptors: NUM_RX_QUEUE_ENTRIES,
+                rx_index: 0,
+                bufs_in_use: Vec::with_capacity(NUM_RX_QUEUE_ENTRIES),
+            };
+
+            self.rx_queues.push(rx_queue);
+        }
+
+        // probably a broken feature, this flag is initialized with 1 but has to be set to 0
+        for i in 0..self.num_rx_queues {
+            self.clear_flags32(IXGBE_VFDCA_RXCTRL(u32::from(i)), 1 << 12);
+        }
+
+        Ok(())
+    }
+
+    // section 4.6.8
+    /// Initializes the tx queues of this device.
+    fn init_tx(&mut self) -> Result<(), Box<dyn Error>> {
+        // configure queues
+        for i in 0..self.num_tx_queues {
+            debug!("initializing tx queue {}", i);
+            // section 7.1.9 - setup descriptor ring
+            let ring_size_bytes =
+                NUM_TX_QUEUE_ENTRIES as usize * mem::size_of::<ixgbe_adv_tx_desc>();
+
+            let dma: Dma<ixgbe_adv_tx_desc> = Dma::allocate(ring_size_bytes, true)?;
+            unsafe {
+                memset(dma.virt as *mut u8, ring_size_bytes, 0xff);
+            }
+
+            self.set_reg32(
+                IXGBE_VFTDBAL(u32::from(i)),
+                (dma.phys as u64 & 0xffff_ffff) as u32,
+            );
+            self.set_reg32(IXGBE_VFTDBAH(u32::from(i)), (dma.phys as u64 >> 32) as u32);
+            self.set_reg32(IXGBE_VFTDLEN(u32::from(i)), ring_size_bytes as u32);
+
+            debug!("tx ring {} phys addr: {:#x}", i, dma.phys);
+            debug!("tx ring {} virt addr: {:p}", i, dma.virt);
+
+            // descriptor writeback magic values, important to get good performance and low PCIe overhead
+            // see 7.2.3.4.1 and 7.2.3.5 for an explanation of these values and how to find good ones
+            // we just use the defaults from DPDK here, but this is a potentially interesting point for optimizations
+            let mut txdctl = self.get_reg32(IXGBE_VFTXDCTL(u32::from(i)));
+            // there are no defines for this in constants.rs for some reason
+            // pthresh: 6:0, hthresh: 14:8, wthresh: 22:16
+            txdctl &= !(0x3F | (0x3F << 8) | (0x3F << 16));
+            txdctl |= 36 | (8 << 8) | (4 << 16);
+
+            self.set_reg32(IXGBE_VFTXDCTL(u32::from(i)), txdctl);
+
+            let tx_queue = IxgbeTxQueue {
+                descriptors: dma.virt,
+                bufs_in_use: VecDeque::with_capacity(NUM_TX_QUEUE_ENTRIES),
+                pool: None,
+                num_descriptors: NUM_TX_QUEUE_ENTRIES,
+                clean_index: 0,
+                tx_index: 0,
+            };
+
+            self.tx_queues.push(tx_queue);
+        }
+
+        Ok(())
+    }
+
+    /// Sets the rx queues` descriptors and enables the queues.
+    fn start_rx_queue(&mut self, queue_id: u16) -> Result<(), Box<dyn Error>> {
+        debug!("starting rx queue {}", queue_id);
+
+        let queue = &mut self.rx_queues[queue_id as usize];
+
+        if queue.num_descriptors & (queue.num_descriptors - 1) != 0 {
+            return Err("number of queue entries must be a power of 2".into());
+        }
+
+        for i in 0..queue.num_descriptors {
+            let pool = &queue.pool;
+
+            let buf = match pool.alloc_buf() {
+                Some(x) => x,
+                None => return Err("failed to allocate rx descriptor".into()),
+            };
+
+            unsafe {
+                ptr::write_volatile(
+                    &mut (*queue.descriptors.add(i)).read.pkt_addr as *mut u64,
+                    pool.get_phys_addr(buf) as u64,
+                );
+
+                ptr::write_volatile(
+                    &mut (*queue.descriptors.add(i)).read.hdr_addr as *mut u64,
+                    0,
+                );
+            }
+
+            // we need to remember which descriptor entry belongs to which mempool entry
+            queue.bufs_in_use.push(buf);
+        }
+
+        let queue = &self.rx_queues[queue_id as usize];
+
+        // enable queue and wait if necessary
+        self.set_flags32(IXGBE_VFRXDCTL(u32::from(queue_id)), IXGBE_RXDCTL_ENABLE);
+        self.wait_set_reg32(IXGBE_VFRXDCTL(u32::from(queue_id)), IXGBE_RXDCTL_ENABLE);
+
+        // rx queue starts out full
+        self.set_reg32(IXGBE_VFRDH(u32::from(queue_id)), 0);
+
+        // was set to 0 before in the init function
+        self.set_reg32(
+            IXGBE_VFRDT(u32::from(queue_id)),
+            (queue.num_descriptors - 1) as u32,
+        );
+
+        Ok(())
+    }
+
+    /// Enables the tx queues.
+    fn start_tx_queue(&mut self, queue_id: u16) -> Result<(), Box<dyn Error>> {
+        debug!("starting tx queue {}", queue_id);
+
+        let queue = &mut self.tx_queues[queue_id as usize];
+
+        if queue.num_descriptors & (queue.num_descriptors - 1) != 0 {
+            return Err("number of queue entries must be a power of 2".into());
+        }
+
+        // tx queue starts out empty
+        self.set_reg32(IXGBE_VFTDH(u32::from(queue_id)), 0);
+        self.set_reg32(IXGBE_VFTDT(u32::from(queue_id)), 0);
+
+        // enable queue and wait if necessary
+        self.set_flags32(IXGBE_VFTXDCTL(u32::from(queue_id)), IXGBE_TXDCTL_ENABLE);
+        self.wait_set_reg32(IXGBE_VFTXDCTL(u32::from(queue_id)), IXGBE_TXDCTL_ENABLE);
+
+        Ok(())
+    }
+
+    /// Enables or disables promiscuous mode of this device.
+    #[allow(dead_code)]
+    fn set_promisc(&self, _enabled: bool) {
+        unimplemented!("PF driver do not support promiscuous mode for VFs yet, see chapter 7.1 in the Intel 82599 SR-IOV driver companion guide");
+    }
+
+    /// Returns the register at `self.addr` + `reg`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `self.addr` + `reg` does not belong to the mapped memory of the pci device.
+    fn get_reg32(&self, reg: u32) -> u32 {
+        assert!(
+            reg as usize <= self.len - 4 as usize,
+            "memory access out of bounds"
+        );
+
+        unsafe { ptr::read_volatile((self.addr as usize + reg as usize) as *mut u32) }
+    }
+
+    /// Sets the register at `self.addr` + `reg` to `value`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `self.addr` + `reg` does not belong to the mapped memory of the pci device.
+    fn set_reg32(&self, reg: u32, value: u32) {
+        assert!(
+            reg as usize <= self.len - 4 as usize,
+            "memory access out of bounds"
+        );
+
+        unsafe {
+            ptr::write_volatile((self.addr as usize + reg as usize) as *mut u32, value);
+        }
+    }
+
+    /// Sets the `flags` at `self.addr` + `reg`.
+    fn set_flags32(&self, reg: u32, flags: u32) {
+        self.set_reg32(reg, self.get_reg32(reg) | flags);
+    }
+
+    /// Clears the `flags` at `self.addr` + `reg`.
+    fn clear_flags32(&self, reg: u32, flags: u32) {
+        self.set_reg32(reg, self.get_reg32(reg) & !flags);
+    }
+
+    /// Waits for `self.addr` + `reg` to clear `value`.
+    #[allow(dead_code)]
+    fn wait_clear_reg32(&self, reg: u32, value: u32) {
+        loop {
+            let current = self.get_reg32(reg);
+            if (current & value) == 0 {
+                break;
+            }
+            thread::sleep(Duration::from_millis(100));
+        }
+    }
+
+    /// Waits for `self.addr` + `reg` to set `value`.
+    fn wait_set_reg32(&self, reg: u32, value: u32) {
+        loop {
+            let current = self.get_reg32(reg);
+            if (current & value) == value {
+                break;
+            }
+            thread::sleep(Duration::from_millis(100));
+        }
+    }
+
+    /// Returns the register at `self.addr` + `reg` + (`index` * 4).
+    ///
+    /// # Panics
+    ///
+    /// Panics if `self.addr` + `reg` + (`index` * 4) does not belong to the mapped memory of the pci device.
+    fn get_reg32_array(&self, reg: u32, index: u32) -> u32 {
+        let idx = reg + (index << 2);
+
+        assert!(
+            idx as usize <= self.len - 4 as usize,
+            "memory access out of bounds"
+        );
+
+        unsafe { ptr::read_volatile((self.addr as usize + idx as usize) as *mut u32) }
+    }
+
+    /// Sets the register at `self.addr` + `reg` + (`index` * 4) to `value`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `self.addr` + `reg` + (`index` * 4) does not belong to the mapped memory of the pci device.
+    fn set_reg32_array(&self, reg: u32, index: u32, value: u32) {
+        let idx = reg + (index << 2);
+
+        assert!(
+            idx as usize <= self.len - 4 as usize,
+            "memory access out of bounds"
+        );
+
+        unsafe {
+            ptr::write_volatile((self.addr as usize + idx as usize) as *mut u32, value);
+        }
+    }
+
+    /// Clears all interrupt masks for all queues.
+    fn clear_interrupts(&self) {
+        // Clear interrupt mask
+        self.set_reg32(IXGBE_VTEIMC, IXGBE_VF_IRQ_CLEAR_MASK);
+
+        // Clear any pending interrupts
+        self.get_reg32(IXGBE_VTEICR);
+    }
+
+    /// Disables all interrupts for all queues.
+    fn disable_interrupts(&self) {
+        self.clear_interrupts();
+    }
+
+    /// Waits for reset from PF.
+    fn wait_check_for_rst(&mut self) -> Result<(), Box<dyn Error>> {
+        let mut countdown = self.mbx.borrow().timeout;
+
+        while countdown > 0 && !self.check_for_rst() {
+            countdown -= 1;
+            thread::sleep(Duration::from_micros(5));
+        }
+
+        if countdown == 0 {
+            Err("timeout while checking for reset".into())
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Checks if the PF has sent a message.
+    fn check_for_msg(&self) -> bool {
+        if !self.check_for_bit(IXGBE_VFMAILBOX_PFSTS) {
+            self.mbx.borrow_mut().reqs += 1;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Checks if the PF has sent ack.
+    fn check_for_ack(&self) -> bool {
+        if !self.check_for_bit(IXGBE_VFMAILBOX_PFACK) {
+            self.mbx.borrow_mut().acks += 1;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Checks if the PF has sent reset.
+    fn check_for_rst(&self) -> bool {
+        if !self.check_for_bit(IXGBE_VFMAILBOX_RSTD | IXGBE_VFMAILBOX_RSTI) {
+            self.mbx.borrow_mut().rsts += 1;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Checks for the read to clear bits within the V2P mailbox.
+    fn check_for_bit(&self, mask: u32) -> bool {
+        let v2p_mailbox = self.read_v2p_mbx();
+
+        self.mbx.borrow_mut().v2p_mailbox &= !mask;
+
+        (v2p_mailbox & mask) != 0x0
+    }
+
+    /// Reads the v2p mailbox without losing the read to clear status bits.
+    fn read_v2p_mbx(&self) -> u32 {
+        let mut v2p_mailbox = self.get_reg32(IXGBE_VFMAILBOX);
+
+        v2p_mailbox |= self.mbx.borrow().v2p_mailbox;
+        self.mbx.borrow_mut().v2p_mailbox |= v2p_mailbox & IXGBE_VFMAILBOX_R2C_BITS;
+
+        v2p_mailbox
+    }
+
+    /// Writes a message to the mailbox, waits for ack, reads a message from the mailbox.
+    fn wait_write_read_msg_mbx(&self, msg: &mut [u32]) -> Result<(), Box<dyn Error>> {
+        self.wait_write_msg_to_mbx(msg)?;
+        self.wait_read_msg_from_mbx(msg)?;
+
+        Ok(())
+    }
+
+    /// Writes a message to the mailbox, waits for ack.
+    fn wait_write_msg_to_mbx(&self, msg: &[u32]) -> Result<(), Box<dyn Error>> {
+        self.write_msg_to_mbx(msg)?;
+        self.wait_for_ack()?;
+
+        Ok(())
+    }
+
+    /// Waits for ack from PF.
+    fn wait_for_ack(&self) -> Result<(), Box<dyn Error>> {
+        let mut countdown = self.mbx.borrow().timeout;
+
+        while countdown > 0 && self.check_for_ack() {
+            countdown -= 1;
+            thread::sleep(Duration::from_micros(self.mbx.borrow().usec_delay as u64));
+        }
+
+        if countdown == 0 {
+            Err("timeout while polling for ack".into())
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Waits for message from PF.
+    fn wait_for_msg(&self) -> Result<(), Box<dyn Error>> {
+        let mut countdown = self.mbx.borrow().timeout;
+
+        while countdown > 0 && self.check_for_msg() {
+            countdown -= 1;
+            thread::sleep(Duration::from_micros(self.mbx.borrow().usec_delay as u64));
+        }
+
+        if countdown == 0 {
+            Err("timeout while polling for message".into())
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Writes a message to the mailbox.
+    fn write_msg_to_mbx(&self, msg: &[u32]) -> Result<(), Box<dyn Error>> {
+        assert!(
+            msg.len() <= self.mbx.borrow().size as usize,
+            "invalid mailbox message size"
+        );
+
+        // lock mailbox to prevent pf/vf race condition
+        self.obtain_mbx_lock()?;
+
+        // flush msg and acks as we are overwriting the message buffer
+        self.check_for_msg();
+        self.check_for_ack();
+
+        // copy message to mailbox memory buffer
+        for (idx, el) in msg.iter().enumerate() {
+            self.set_reg32_array(IXGBE_VFMBMEM, idx as u32, *el);
+        }
+
+        // update stats
+        self.mbx.borrow_mut().msgs_tx += 1;
+
+        // Drop VFU and interrupt the PF to tell it a message has been sent
+        self.set_reg32(IXGBE_VFMAILBOX, IXGBE_VFMAILBOX_REQ);
+
+        Ok(())
+    }
+
+    /// Receives (and waits for) a message from the mailbox.
+    fn wait_read_msg_from_mbx(&self, msg: &mut [u32]) -> Result<(), Box<dyn Error>> {
+        self.wait_for_msg()?;
+        self.read_msg_from_mbx(msg)?;
+
+        Ok(())
+    }
+
+    /// Reads a message from the mailbox.
+    fn read_msg_from_mbx(&self, msg: &mut [u32]) -> Result<(), Box<dyn Error>> {
+        let len = min(msg.len(), self.mbx.borrow().size as usize);
+
+        // lock mailbox to prevent pf/vf race condition
+        self.obtain_mbx_lock()?;
+
+        // copy message from mailbox memory buffer
+        for (idx, el) in msg[0..len].iter_mut().enumerate() {
+            *el = self.get_reg32_array(IXGBE_VFMBMEM, idx as u32);
+        }
+
+        // Acknowledge receipt and release mailbox, then we're done
+        self.set_reg32(IXGBE_VFMAILBOX, IXGBE_VFMAILBOX_ACK);
+
+        // update stats
+        self.mbx.borrow_mut().msgs_rx += 1;
+
+        Ok(())
+    }
+
+    /// Obtains the mailbox lock.
+    fn obtain_mbx_lock(&self) -> Result<(), Box<dyn Error>> {
+        // take ownership of the buffer
+        self.set_reg32(IXGBE_VFMAILBOX, IXGBE_VFMAILBOX_VFU);
+
+        // reserve mailbox for vf use
+        if (self.read_v2p_mbx() & IXGBE_VFMAILBOX_VFU) != 0x0 {
+            Ok(())
+        } else {
+            Err("failed to obtain mailbox lock".into())
+        }
+    }
+}
+
+/// Removes multiples of `TX_CLEAN_BATCH` packets from `queue`.
+fn clean_tx_queue(queue: &mut IxgbeTxQueue) -> usize {
+    let mut clean_index = queue.clean_index;
+    let cur_index = queue.tx_index;
+
+    loop {
+        let mut cleanable = cur_index as i32 - clean_index as i32;
+
+        if cleanable < 0 {
+            cleanable += queue.num_descriptors as i32;
+        }
+
+        if cleanable < TX_CLEAN_BATCH as i32 {
+            break;
+        }
+
+        let mut cleanup_to = clean_index + TX_CLEAN_BATCH - 1;
+
+        if cleanup_to >= queue.num_descriptors {
+            cleanup_to -= queue.num_descriptors;
+        }
+
+        let status = unsafe {
+            ptr::read_volatile(&(*queue.descriptors.add(cleanup_to)).wb.status as *const u32)
+        };
+
+        if (status & IXGBE_ADVTXD_STAT_DD) != 0 {
+            if let Some(ref p) = queue.pool {
+                if TX_CLEAN_BATCH as usize >= queue.bufs_in_use.len() {
+                    p.free_stack
+                        .borrow_mut()
+                        .extend(queue.bufs_in_use.drain(..))
+                } else {
+                    p.free_stack
+                        .borrow_mut()
+                        .extend(queue.bufs_in_use.drain(..TX_CLEAN_BATCH))
+                }
+            }
+
+            clean_index = wrap_ring(cleanup_to, queue.num_descriptors);
+        } else {
+            break;
+        }
+    }
+
+    queue.clean_index = clean_index;
+
+    clean_index
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -212,10 +212,12 @@ pub fn ixy_init(
     tx_queues: u16,
     interrupt_timeout: i16,
 ) -> Result<Box<dyn IxyDevice>, Box<dyn Error>> {
-    let mut config_file = pci_open_resource(pci_addr, "config").expect("wrong pci address");
+    let mut vendor_file = pci_open_resource_ro(pci_addr, "vendor").expect("wrong pci address");
+    let mut device_file = pci_open_resource_ro(pci_addr, "device").expect("wrong pci address");
+    let mut config_file = pci_open_resource_ro(pci_addr, "config").expect("wrong pci address");
 
-    let vendor_id = read_io16(&mut config_file, 0)?;
-    let device_id = read_io16(&mut config_file, 2)?;
+    let vendor_id = read_hex(&mut vendor_file)?;
+    let device_id = read_hex(&mut device_file)?;
     let class_id = read_io32(&mut config_file, 8)? >> 24;
 
     if class_id != 2 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,8 +30,6 @@ use std::collections::VecDeque;
 use std::error::Error;
 use std::os::unix::io::RawFd;
 
-const MAX_QUEUES: u16 = 64;
-
 /// Used for implementing an ixy device driver like ixgbe or virtio.
 pub trait IxyDevice {
     /// Initializes an intel 82599 network card.


### PR DESCRIPTION
This PR adds partial SR-IOV support by adding a driver implementation for virtual functions (VFs), i.e. `ixgbevf`.